### PR TITLE
Sync submodules before updating git submodules

### DIFF
--- a/builder/source/git.go
+++ b/builder/source/git.go
@@ -253,8 +253,12 @@ func (g *GitSource) resetOnto(repo *git.Repository, ref string) error {
 // submodules will handle setup of the git submodules after a
 // reset has taken place.
 func (g *GitSource) submodules() error {
+    cmd := []string{"submodule", "sync"}
+    if err := commands.ExecStdoutArgsDir(g.ClonePath, "git", cmd); err != nil {
+        return err
+    }
 	// IDK What else to tell ya, git2go submodules is broken
-	cmd := []string{"submodule", "update", "--init", "--recursive"}
+	cmd = []string{"submodule", "update", "--init", "--recursive"}
 	return commands.ExecStdoutArgsDir(g.ClonePath, "git", cmd)
 }
 


### PR DESCRIPTION
When updating pytorch, I ran into pytorch/pytorch#29109, and had to run git submodule sync before updating submodules. This PR fixes it.