### PR TITLE
Cleanup properly if a SIGINT or SIGTERM is received

### DIFF
--- a/builder/manager.go
+++ b/builder/manager.go
@@ -320,7 +320,7 @@ func (m *Manager) doLock(path, opType string) error {
 // SigIntCleanup will take care of cleaning up the build process.
 func (m *Manager) SigIntCleanup() {
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt)
+	signal.Notify(ch, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-ch
 		log.Warning("CTRL+C interrupted, cleaning up")


### PR DESCRIPTION
This is an attempt to stop systemd-oomd nuking local repos if it sends a SIGINT or SIGTERM.

Generally local repos will not get nuked if you manually SIGINT or SIGTERM solbuild so it is hard to say whether this will completely solve the issue.