### PR TITLE
Integrate sccache

### DIFF
--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -182,6 +182,7 @@ func (e *EopkgManager) Upgrade() error {
 	// proper containerized functionality.
 	newReqs := []string{
 		"iproute2",
+		"sccache",
 	}
 	if err := ChrootExec(e.notif, e.root, eopkgCommand("eopkg upgrade -y")); err != nil {
 		return err

--- a/builder/main.go
+++ b/builder/main.go
@@ -53,6 +53,12 @@ const (
 
 	// LegacyCcacheDirectory is the root owned ccache directory for pspec.xml
 	LegacyCcacheDirectory = "/var/lib/solbuild/ccache/legacy"
+
+	// SccacheDirectory is the root owned sccache directory
+	SccacheDirectory = "/var/lib/solbuild/sccache/ypkg"
+
+	// LegacySccacheDirectory is the root owned ccache directory for pspec.xml
+	LegacySccacheDirectory = "/var/lib/solbuild/sccache/legacy"
 )
 
 const (

--- a/cli/delete_cache.go
+++ b/cli/delete_cache.go
@@ -41,7 +41,7 @@ var DeleteCache = cmd.Sub{
 
 // DeleteCacheFlags are the flags for the "delete-cache" sub-command
 type DeleteCacheFlags struct {
-	All    bool `short:"a" long:"all"    desc:"Additionally delete ccache, packages and sources"`
+	All    bool `short:"a" long:"all"    desc:"Additionally delete (s)ccache, packages and sources"`
 	Images bool `short:"i" long:"images" desc:"Additionally delete solbuild images"`
 }
 
@@ -70,6 +70,8 @@ func DeleteCacheRun(r *cmd.Root, s *cmd.Sub) {
 		nukeDirs = append(nukeDirs, []string{
 			builder.CcacheDirectory,
 			builder.LegacyCcacheDirectory,
+			builder.SccacheDirectory,
+			builder.LegacySccacheDirectory,
 			builder.PackageCacheDirectory,
 			source.SourceDir,
 		}...)


### PR DESCRIPTION
Fixes #14.

Integrate `sccache` into `solbuild`. This will make Rust builds much faster and saner. `ccache` is not replaced and still being used for caching C/C++ builds.

Initial testing has been completed (with locally modified `ypkg`, see getsolus/ypkg#26) and the results are promising. `bottom`, a 211-job Rust project, can be reduced from 4 minutes and 5 seconds to 2 minutes and 18 seconds. This result is not considering that both take about a minute to fetch the crates.io index.

A final testing is needed after both `sccache` and `ypkg` are updated in the official repository.

Signed-off-by: Gavin Zhao <git@gzgz.dev>
