### PR TITLE
Update git2go to v33

### DIFF
--- a/builder/history.go
+++ b/builder/history.go
@@ -20,7 +20,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	git "github.com/libgit2/git2go/v31"
+	git "github.com/libgit2/git2go/v32"
 	"os"
 	"path/filepath"
 	"regexp"

--- a/builder/history.go
+++ b/builder/history.go
@@ -20,7 +20,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	git "github.com/libgit2/git2go/v32"
+	git "github.com/libgit2/git2go/v33"
 	"os"
 	"path/filepath"
 	"regexp"

--- a/builder/source/git.go
+++ b/builder/source/git.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/libosdev/commands"
-	git "github.com/libgit2/git2go/v31"
+	git "github.com/libgit2/git2go/v32"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -80,9 +80,9 @@ func (g *GitSource) completed(r git.RemoteCompletion) git.ErrorCode {
 }
 
 // message will be called to emit standard git text to the terminal
-func (g *GitSource) message(str string) git.ErrorCode {
+func (g *GitSource) message(str string) error {
 	os.Stdout.Write([]byte(str))
-	return 0
+	return nil
 }
 
 // CreateCallbacks will create the default git callbacks
@@ -104,7 +104,7 @@ func (g *GitSource) Clone() error {
 
 	_, err := git.Clone(g.URI, g.ClonePath, &git.CloneOptions{
 		Bare:         false,
-		FetchOptions: fetchOpts,
+		FetchOptions: *fetchOpts,
 	})
 	return err
 }

--- a/builder/source/git.go
+++ b/builder/source/git.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/libosdev/commands"
-	git "github.com/libgit2/git2go/v32"
+	git "github.com/libgit2/git2go/v33"
 	"net/url"
 	"os"
 	"path/filepath"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/getsolus/libosdev v0.0.0-20181023041421-9ab0f4b463fd
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/libgit2/git2go/v32 v32.1.9
+	github.com/libgit2/git2go/v33 v33.0.9
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/solus-project/libosdev v0.0.0-20171113084438-39032fc50772 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/getsolus/libosdev v0.0.0-20181023041421-9ab0f4b463fd
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/libgit2/git2go/v31 v31.7.9
+	github.com/libgit2/git2go/v32 v32.1.9
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/solus-project/libosdev v0.0.0-20171113084438-39032fc50772 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/libgit2/git2go/v31 v31.7.9 h1:RUDiYm7+i3GY414acI31oDD8x5P0PZyWeZZfwpPuynE=
-github.com/libgit2/git2go/v31 v31.7.9/go.mod h1:c/rkJcBcUFx6wHaT++UwNpKvIsmPNqCeQ/vzO4DrEec=
++github.com/libgit2/git2go/v32 v32.1.9 h1:RjHicBhR3vi7u86cU6Km912rQunjf6PCGbQa8g1x+hQ=
++github.com/libgit2/git2go/v32 v32.1.9/go.mod h1:FAA2ePV5PlLjw1ccncFIvu2v8hJSZVN5IzEn4lo/vwo=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-+github.com/libgit2/git2go/v32 v32.1.9 h1:RjHicBhR3vi7u86cU6Km912rQunjf6PCGbQa8g1x+hQ=
-+github.com/libgit2/git2go/v32 v32.1.9/go.mod h1:FAA2ePV5PlLjw1ccncFIvu2v8hJSZVN5IzEn4lo/vwo=
+github.com/libgit2/git2go/v33 v33.0.9 h1:4ch2DJed6IhJO28BEohkUoGvxLsRzUjxljoNFJ6/O78=
+github.com/libgit2/git2go/v33 v33.0.9/go.mod h1:KdpqkU+6+++4oHna/MIOgx4GCQ92IPCdpVRMRI80J+4=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
Fixes #16.

Code is now compatible with the newest API changes for v32+.

Tested with a simple git source `package.yml`.