### PR TITLE
Allow for renaming of simple source files

### DIFF
--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -49,6 +49,7 @@ func NewSimple(uri, validator string, legacy bool) (*SimpleSource, error) {
 		return nil, err
 	}
 	fileName := filepath.Base(uriObj.Path)
+	//support URI fragments for renaming sources
 	if uriObj.Fragment != "" {
 		fileName = uriObj.Fragment
 		uriObj.Fragment = ""

--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -48,9 +48,15 @@ func NewSimple(uri, validator string, legacy bool) (*SimpleSource, error) {
 	if err != nil {
 		return nil, err
 	}
+	fileName := filepath.Base(uriObj.Path)
+	if uriObj.Fragment != "" {
+		fileName = uriObj.Fragment
+		uriObj.Fragment = ""
+	}
+	
 	ret := &SimpleSource{
-		URI:       uri,
-		File:      filepath.Base(uriObj.Path),
+		URI:       uriObj.String(),
+		File:      fileName,
 		legacy:    legacy,
 		validator: validator,
 		url:       uriObj,


### PR DESCRIPTION
This is meant to go with https://github.com/getsolus/ypkg/pull/29
With this patch it is now downloading the source with the filename specified by `#newFileName` put at the end of the file, and it is correctly exposing it to container. 
Turns out when I build solbuilt it didn't use the update `ypkg`. So both patches are fine.