### PR TITLE
Fix Unstable repo URI for local-unstable profile

### DIFF
--- a/data/local-unstable-x86_64.profile
+++ b/data/local-unstable-x86_64.profile
@@ -30,4 +30,4 @@ autoindex = true
 
 # Re-add the Solus unstable repo
 [repo.Solus]
-uri = "https://mirrors.rit.edu/solus/packages/unstable/eopkg-index.xml.xz"
+uri = "https://cdn.getsol.us/unstable/eopkg-index.xml.xz"


### PR DESCRIPTION
Without this it pulls old packages from the RIT mirror and/or fails the build due to unmatched dependencies.

Discovered by aleksvor