### PR TITLE
Refactor cache, take 2

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -60,7 +60,6 @@ func (p *Package) CreateDirs(o *Overlay) error {
 			if err := os.Chown(hostCacheDir, BuildUserID, BuildUserGID); err != nil {
 				return fmt.Errorf("Failed to chown cache directory %s in build root, reason: %w", inRootCacheDir, err)
 			}
-
 		}
 	}
 

--- a/builder/build.go
+++ b/builder/build.go
@@ -115,13 +115,15 @@ func (p *Package) BindSources(o *Overlay) error {
 	return nil
 }
 
-// BindCache will make all cache defined in [caches] available to the build
+// BindCache will make all cache defined in [caches] available to the build.
 func (p *Package) BindCaches(o *Overlay) error {
 	mountMan := disk.GetMountManager()
 
 	for _, c := range Caches {
-		var cacheSource string
-		var cacheDir string
+		var (
+			cacheSource string
+			cacheDir    string
+		)
 
 		if p.Type == PackageTypeYpkg {
 			cacheSource = filepath.Join(CacheDirectory, c.Name, "ypkg")
@@ -132,8 +134,9 @@ func (p *Package) BindCaches(o *Overlay) error {
 
 		// Bind mount local ccache into chroot
 		if err := mountMan.BindMount(cacheSource, cacheDir); err != nil {
-			return fmt.Errorf("Failed to bind mount %s %s, reason: %s\n", c.Name, cacheDir, err)
+			return fmt.Errorf("Failed to bind mount %s %s, reason: %w\n", c.Name, cacheDir, err)
 		}
+
 		o.ExtraMounts = append(o.ExtraMounts, cacheDir)
 	}
 

--- a/builder/build.go
+++ b/builder/build.go
@@ -117,18 +117,15 @@ func (p *Package) BindSources(o *Overlay) error {
 
 // BindCache will make all cache defined in [caches] available to the build.
 func (p *Package) BindCaches(o *Overlay) error {
+	if p.Type == PackageTypeXML {
+		return fmt.Errorf("Failed to bind caches, reason: not YPKG build")
+	}
+
 	mountMan := disk.GetMountManager()
 
 	for _, c := range Caches {
-		var (
-			cacheSource string
-			cacheDir    string
-		)
-
-		if p.Type == PackageTypeYpkg {
-			cacheSource = filepath.Join(CacheDirectory, c.Name, "ypkg")
-			cacheDir = filepath.Join(o.MountPoint, c.CacheDir[1:])
-		}
+		cacheSource := filepath.Join(CacheDirectory, c.Name, "ypkg")
+		cacheDir := filepath.Join(o.MountPoint, c.CacheDir[1:])
 
 		log.Debugf("Exposing %s to build %s\n", c.Name, cacheDir)
 
@@ -171,36 +168,6 @@ func (p *Package) GetSourceDirInternal() string {
 	}
 
 	return filepath.Join(BuildUserHome, "YPKG", "sources")
-}
-
-// GetCcacheDir will return the externally visible ccache directory.
-func (p *Package) GetCcacheDir(o *Overlay) string {
-	return filepath.Join(o.MountPoint, p.GetCcacheDirInternal()[1:])
-}
-
-// GetCcacheDirInternal will return the chroot-internal ccache directory
-// for the given build type.
-func (p *Package) GetCcacheDirInternal() string {
-	if p.Type == PackageTypeXML {
-		return "/root/.ccache"
-	}
-
-	return filepath.Join(BuildUserHome, ".ccache")
-}
-
-// GetSccacheDir will return the externally visible sccache directory.
-func (p *Package) GetSccacheDir(o *Overlay) string {
-	return filepath.Join(o.MountPoint, p.GetSccacheDirInternal()[1:])
-}
-
-// GetSccacheDirInternal will return the chroot-internal sccache
-// directory for the given build type.
-func (p *Package) GetSccacheDirInternal() string {
-	if p.Type == PackageTypeXML {
-		return "/root/.cache/sccache"
-	}
-
-	return filepath.Join(BuildUserHome, ".cache", "sccache")
 }
 
 // CopyAssets will copy all of the required assets into the builder root.

--- a/builder/build.go
+++ b/builder/build.go
@@ -32,6 +32,8 @@ func (p *Package) CreateDirs(o *Overlay) error {
 		p.GetWorkDir(o),
 		p.GetSourceDir(o),
 	}
+
+	// Add cache directories.
 	if p.Type == PackageTypeYpkg {
 		for _, cache := range Caches {
 			dirs = append(dirs, filepath.Join(o.MountPoint, cache.CacheDir[1:]))

--- a/builder/cache.go
+++ b/builder/cache.go
@@ -1,0 +1,24 @@
+package builder
+
+import (
+	"path"
+)
+
+var (
+	Ccache = Cache{
+		Name:     "ccache",
+		CacheDir: path.Join(BuildUserHome, ".ccache"),
+	}
+
+	Sccache = Cache{
+		Name:     "sccache",
+		CacheDir: path.Join(BuildUserHome, ".cache", "sccache"),
+	}
+
+	Caches = []Cache{Ccache, Sccache}
+)
+
+type Cache struct {
+	Name     string
+	CacheDir string // CacheDir is the chroot-internal cache directory.
+}

--- a/builder/cache.go
+++ b/builder/cache.go
@@ -15,7 +15,17 @@ var (
 		CacheDir: path.Join(BuildUserHome, ".cache", "sccache"),
 	}
 
-	Caches = []Cache{Ccache, Sccache}
+	Bazel = Cache{
+		Name:     "bazel",
+		CacheDir: path.Join(BuildUserHome, ".cache", "bazel"),
+	}
+
+	GoBuild = Cache{
+		Name:     "go-build",
+		CacheDir: path.Join(BuildUserHome, ".cache", "go-build"),
+	}
+
+	Caches = []Cache{Bazel, Ccache, GoBuild, Sccache}
 )
 
 type Cache struct {

--- a/builder/main.go
+++ b/builder/main.go
@@ -51,7 +51,7 @@ const (
 	// PackageCacheDirectory is where we share packages between all builders.
 	PackageCacheDirectory = "/var/lib/solbuild/packages"
 
-	// CacheDirectory is where packages' build cache are stored
+	// CacheDirectory is where packages' build cache are stored.
 	CacheDirectory = "/var/lib/solbuild/cache"
 
 	// Obsolete cache directories. These are only still specified so that the

--- a/builder/main.go
+++ b/builder/main.go
@@ -51,17 +51,16 @@ const (
 	// PackageCacheDirectory is where we share packages between all builders.
 	PackageCacheDirectory = "/var/lib/solbuild/packages"
 
-	// CcacheDirectory is the system wide ccache directory.
-	CcacheDirectory = "/var/lib/solbuild/ccache/ypkg"
+	// CacheDirectory is where packages' build cache are stored
+	CacheDirectory = "/var/lib/solbuild/cache"
 
-	// LegacyCcacheDirectory is the root owned ccache directory for pspec.xml.
-	LegacyCcacheDirectory = "/var/lib/solbuild/ccache/legacy"
-
-	// SccacheDirectory is the root owned sccache directory.
-	SccacheDirectory = "/var/lib/solbuild/sccache/ypkg"
-
-	// LegacySccacheDirectory is the root owned ccache directory for pspec.xml.
-	LegacySccacheDirectory = "/var/lib/solbuild/sccache/legacy"
+	// Obsolete cache directories. These are only still specified so that the
+	// `delete-cache -a` subcommand will remove them. In the future they will
+	// be removed.
+	ObsoleteCcacheDirectory        = "/var/lib/solbuild/ccache/ypkg"
+	ObsoleteLegacyCcacheDirectory  = "/var/lib/solbuild/ccache/legacy"
+	ObsoleteSccacheDirectory       = "/var/lib/solbuild/sccache/ypkg"
+	ObsoleteLegacySccacheDirectory = "/var/lib/solbuild/sccache/legacy"
 )
 
 const (

--- a/cli/delete_cache.go
+++ b/cli/delete_cache.go
@@ -76,10 +76,11 @@ func DeleteCacheRun(r *cmd.Root, s *cmd.Sub) {
 	if sFlags.Sizes {
 		sizeDirs := []string{
 			manager.Config.OverlayRootDir,
-			builder.CcacheDirectory,
-			builder.LegacyCcacheDirectory,
-			builder.SccacheDirectory,
-			builder.LegacySccacheDirectory,
+			builder.CacheDirectory,
+			builder.ObsoleteCcacheDirectory,
+			builder.ObsoleteSccacheDirectory,
+			builder.ObsoleteLegacyCcacheDirectory,
+			builder.ObsoleteLegacySccacheDirectory,
 			builder.PackageCacheDirectory,
 			source.SourceDir,
 		}
@@ -108,10 +109,11 @@ func DeleteCacheRun(r *cmd.Root, s *cmd.Sub) {
 	}
 	if sFlags.All {
 		nukeDirs = append(nukeDirs, []string{
-			builder.CcacheDirectory,
-			builder.LegacyCcacheDirectory,
-			builder.SccacheDirectory,
-			builder.LegacySccacheDirectory,
+			builder.CacheDirectory,
+			builder.ObsoleteCcacheDirectory,
+			builder.ObsoleteSccacheDirectory,
+			builder.ObsoleteLegacyCcacheDirectory,
+			builder.ObsoleteLegacySccacheDirectory,
 			builder.PackageCacheDirectory,
 			source.SourceDir,
 		}...)


### PR DESCRIPTION
Related to #23. Supersedes #24. I'm too lazy to rebase.

- Refactor build cache to make it trivial to add new build cache directories (e.g. Cargo, Go, Bazel).
- Drop build cache support for legacy XML builds, as suggested by @joebonrichie.

Tested against both the YPKG format and the Pspec format.