### PR TITLE
Replace waterlog by slog

### DIFF
--- a/builder/chroot.go
+++ b/builder/chroot.go
@@ -18,15 +18,16 @@ package builder
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/libosdev/commands"
 )
 
 // Chroot will attempt to spawn a chroot in the overlayfs system.
 func (p *Package) Chroot(notif PidNotifier, pman *EopkgManager, overlay *Overlay) error {
-	log.Debugf("Beginning chroot: profile='%s' version='%s' package='%s' type='%s' release='%d'\n", overlay.Back.Name, p.Version, p.Name, p.Type, p.Release)
+	slog.Debug("Beginning chroot", "profile", overlay.Back.Name, "version", p.Version,
+		"package", p.Name, "type", p.Type, "release", p.Release)
 
 	var env []string
 	if p.Type == PackageTypeXML {
@@ -53,11 +54,11 @@ func (p *Package) Chroot(notif PidNotifier, pman *EopkgManager, overlay *Overlay
 				return err
 			}
 		} else {
-			log.Warnln("Package has explicitly requested networking, sandboxing disabled")
+			slog.Warn("Package has explicitly requested networking, sandboxing disabled")
 		}
 	}
 
-	log.Debugln("Spawning login shell")
+	slog.Debug("Spawning login shell")
 	// Allow bash to work
 	commands.SetStdin(os.Stdin)
 

--- a/builder/copy.go
+++ b/builder/copy.go
@@ -18,10 +18,10 @@ package builder
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/libosdev/disk"
 )
 
@@ -56,7 +56,7 @@ func CopyAll(source, destdir string) error {
 		}
 	} else {
 		if !PathExists(destdir) {
-			log.Debugf("Creating target directory: %s\n", destdir)
+			slog.Debug("Creating target directory", "dir", destdir)
 
 			if err = os.MkdirAll(destdir, 0o0755); err != nil {
 				return fmt.Errorf("Failed to create target directory: %s, reason: %w\n", destdir, err)
@@ -64,7 +64,7 @@ func CopyAll(source, destdir string) error {
 		}
 
 		tgt := filepath.Join(destdir, filepath.Base(source))
-		log.Debugf("Copying source asset %s to %s\n", source, tgt)
+		slog.Debug("Copying source", "source", source, "target", tgt)
 
 		if err = disk.CopyFile(source, tgt); err != nil {
 			return fmt.Errorf("Failed to copy source asset to target: source='%s' target='%s', reason: %w\n", source, tgt, err)

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -19,11 +19,11 @@ package builder
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/libosdev/commands"
 	"github.com/getsolus/libosdev/disk"
 )
@@ -86,14 +86,14 @@ func (e *EopkgManager) CopyAssets() error {
 
 		dirName := filepath.Dir(value)
 		if !PathExists(dirName) {
-			log.Debugf("Creating required directory: %s\n", dirName)
+			slog.Debug("Creating required directory", "path", dirName)
 
 			if err := os.MkdirAll(dirName, 0o0755); err != nil {
 				return fmt.Errorf("Failed to create required asset directory %s, reason %w\n", dirName, err)
 			}
 		}
 
-		log.Debugf("Copying host asset %s\n", key)
+		slog.Debug("Copying host asset", "key", key)
 
 		if err := disk.CopyFile(key, value); err != nil {
 			return fmt.Errorf("Failed to copy host asset %s, reason: %w\n", key, err)
@@ -118,7 +118,7 @@ func (e *EopkgManager) Init() error {
 
 	// Ensure system wide cache exists
 	if !PathExists(e.cacheSource) {
-		log.Debugf("Creating system-wide package cache: %s\n", e.cacheSource)
+		slog.Debug("Creating system-wide package cache", "path", e.cacheSource)
 
 		if err := os.MkdirAll(e.cacheSource, 0o0755); err != nil {
 			return fmt.Errorf("Failed to create package cache %s, reason: %w\n", e.cacheSource, err)
@@ -296,7 +296,7 @@ func (e *EopkgManager) GetRepos() ([]*EopkgRepo, error) {
 
 	var repoFiles []string
 
-	log.Debugln("Discovering repos in rootfs")
+	slog.Debug("Discovering repos in rootfs")
 
 	repoFiles, _ = filepath.Glob(globPat)
 	// No repos
@@ -309,7 +309,7 @@ func (e *EopkgManager) GetRepos() ([]*EopkgRepo, error) {
 	for _, repo := range repoFiles {
 		uri, err := readURIFile(repo)
 		if err != nil {
-			log.Errorf("Unable to read repository file %s, reason: %s\n", repo, err)
+			slog.Error("Unable to read repository file", "path", repo, "err", err)
 			return nil, err
 		}
 

--- a/builder/namespaces.go
+++ b/builder/namespaces.go
@@ -18,14 +18,13 @@ package builder
 
 import (
 	"fmt"
+	"log/slog"
 	"syscall"
-
-	log "github.com/DataDrake/waterlog"
 )
 
 // ConfigureNamespace will unshare() context, entering a new namespace.
 func ConfigureNamespace() error {
-	log.Debugln("Configuring container namespace")
+	slog.Debug("Configuring container namespace")
 
 	if err := syscall.Unshare(syscall.CLONE_NEWNS | syscall.CLONE_NEWIPC); err != nil {
 		return fmt.Errorf("Failed to configure namespace, reason: %w\n", err)
@@ -36,7 +35,7 @@ func ConfigureNamespace() error {
 
 // DropNetworking will unshare() the context networking capabilities.
 func DropNetworking() error {
-	log.Debugln("Dropping container networking")
+	slog.Debug("Dropping container networking")
 
 	if err := syscall.Unshare(syscall.CLONE_NEWNET | syscall.CLONE_NEWUTS); err != nil {
 		return fmt.Errorf("Failed to drop networking capabilities, reason: %w\n", err)

--- a/builder/repos.go
+++ b/builder/repos.go
@@ -18,10 +18,10 @@ package builder
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/libosdev/disk"
 )
 
@@ -56,7 +56,7 @@ func (p *Package) addLocalRepo(notif PidNotifier, o *Overlay, pkgManager *EopkgM
 
 	// Attempt to autoindex the repo
 	if repo.AutoIndex {
-		log.Debugf("Reindexing repository %s\n", repo.Name)
+		slog.Debug("Reindexing repository", "name", repo.Name)
 
 		command := fmt.Sprintf("cd %s/%s; %s", BindRepoDir, repo.Name, eopkgCommand("eopkg index --skip-signing ."))
 		err := ChrootExec(notif, o.MountPoint, command)
@@ -68,7 +68,7 @@ func (p *Package) addLocalRepo(notif PidNotifier, o *Overlay, pkgManager *EopkgM
 	} else {
 		tgtIndex := filepath.Join(tgt, "eopkg-index.xml.xz")
 		if !PathExists(tgtIndex) {
-			log.Warnf("Repository index doesn't exist. Please index it to use it. %s\n", repo.Name)
+			slog.Warn("Repository index doesn't exist. Please index it to use it.", "repo", repo.Name)
 		}
 	}
 
@@ -84,7 +84,7 @@ func (p *Package) removeRepos(pkgManager *EopkgManager, repos []string) error {
 	}
 
 	for _, id := range repos {
-		log.Debugf("Removing repository %s\n", id)
+		slog.Debug("Removing repository", "repo", id)
 
 		if err := pkgManager.RemoveRepo(id); err != nil {
 			return fmt.Errorf("Failed to remove repository %s, reason: %w\n", id, err)
@@ -102,7 +102,7 @@ func (p *Package) addRepos(notif PidNotifier, o *Overlay, pkgManager *EopkgManag
 
 	for _, repo := range repos {
 		if repo.Local {
-			log.Debugf("Adding local repo to system %s %s\n", repo.Name, repo.URI)
+			slog.Debug("Adding local repo to system", "name", repo.Name, "uri", repo.URI)
 
 			if err := p.addLocalRepo(notif, o, pkgManager, repo); err != nil {
 				return fmt.Errorf("Failed to add local repo to system %s, reason: %w\n", repo.Name, err)
@@ -111,7 +111,7 @@ func (p *Package) addRepos(notif PidNotifier, o *Overlay, pkgManager *EopkgManag
 			continue
 		}
 
-		log.Debugf("Adding repo to system %s %s\n", repo.Name, repo.URI)
+		slog.Debug("Adding repo to system", "name", repo.Name, "uri", repo.URI)
 
 		if err := pkgManager.AddRepo(repo.Name, repo.URI); err != nil {
 			return fmt.Errorf("Failed to add repo to system %s, reason: %w\n", repo.Name, err)

--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -20,12 +20,12 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/cheggaaa/pb/v3"
 )
@@ -159,7 +159,7 @@ func (s *SimpleSource) download(destination string) error {
 			pbar.SetCurrent(resp.BytesComplete())
 
 			if err := resp.Err(); err != nil {
-				log.Errorf("Error downloading %s: %v\n", s.URI, err)
+				slog.Error("Error downloading", "uri", s.URI, "err", err)
 				return err
 			}
 
@@ -171,7 +171,7 @@ func (s *SimpleSource) download(destination string) error {
 // Fetch will download the given source and cache it locally.
 func (s *SimpleSource) Fetch() error {
 	// Now go and download it
-	log.Debugf("Downloading source %s\n", s.URI)
+	slog.Debug("Downloading source", "uri", s.URI)
 
 	destPath := filepath.Join(SourceStagingDir, s.File)
 

--- a/cli/chroot.go
+++ b/cli/chroot.go
@@ -19,15 +19,14 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
 	"github.com/DataDrake/cli-ng/v2/cmd"
-	log "github.com/DataDrake/waterlog"
-	"github.com/DataDrake/waterlog/format"
-	"github.com/DataDrake/waterlog/level"
 
 	"github.com/getsolus/solbuild/builder"
+	"github.com/getsolus/solbuild/cli/log"
 )
 
 func init() {
@@ -53,11 +52,11 @@ func ChrootRun(r *cmd.Root, s *cmd.Sub) {
 	sArgs := s.Args.(*ChrootArgs)    //nolint:forcetypeassert // guaranteed by callee.
 
 	if rFlags.Debug {
-		log.SetLevel(level.Debug)
+		log.Level.Set(slog.LevelDebug)
 	}
 
 	if rFlags.NoColor {
-		log.SetFormat(format.Un)
+		log.SetUncoloredLogger()
 
 		builder.DisableColors = true
 	}
@@ -71,11 +70,11 @@ func ChrootRun(r *cmd.Root, s *cmd.Sub) {
 	}
 
 	if len(pkgPath) == 0 {
-		log.Fatalln("No package.yml or pspec.xml found in current directory and no file provided.")
+		log.Panic("No package.yml or pspec.xml found in current directory and no file provided.")
 	}
 
 	if os.Geteuid() != 0 {
-		log.Fatalln("You must be root to use chroot")
+		log.Panic("You must be root to use chroot")
 	}
 
 	// Initialise the build manager
@@ -90,7 +89,7 @@ func ChrootRun(r *cmd.Root, s *cmd.Sub) {
 
 	pkg, err := builder.NewPackage(pkgPath)
 	if err != nil {
-		log.Fatalf("Failed to load package: %s\n", err)
+		log.Panic("Failed to load package: %s\n", err)
 	}
 	// Set the package
 	if err := manager.SetPackage(pkg); err != nil {
@@ -102,8 +101,8 @@ func ChrootRun(r *cmd.Root, s *cmd.Sub) {
 	}
 
 	if err := manager.Chroot(); err != nil {
-		log.Fatalln("Chroot failure")
+		log.Panic("Chroot failure")
 	}
 
-	log.Infoln("Chroot complete")
+	slog.Info("Chroot complete")
 }

--- a/cli/index.go
+++ b/cli/index.go
@@ -19,14 +19,13 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/DataDrake/cli-ng/v2/cmd"
-	log "github.com/DataDrake/waterlog"
-	"github.com/DataDrake/waterlog/format"
-	"github.com/DataDrake/waterlog/level"
 
 	"github.com/getsolus/solbuild/builder"
+	"github.com/getsolus/solbuild/cli/log"
 )
 
 func init() {
@@ -60,15 +59,15 @@ func IndexRun(r *cmd.Root, s *cmd.Sub) {
 	args := s.Args.(*IndexArgs)      //nolint:forcetypeassert // guaranteed by callee.
 
 	if rFlags.Debug {
-		log.SetLevel(level.Debug)
+		log.Level.Set(slog.LevelDebug)
 	}
 
 	if rFlags.NoColor {
-		log.SetFormat(format.Un)
+		log.SetUncoloredLogger()
 	}
 
 	if os.Geteuid() != 0 {
-		log.Fatalln("You must be root to use index")
+		log.Panic("You must be root to use index")
 	}
 	// Initialise the build manager
 	manager, err := builder.NewManager()
@@ -91,8 +90,8 @@ func IndexRun(r *cmd.Root, s *cmd.Sub) {
 	manager.SetTmpfs(sFlags.Tmpfs, sFlags.Memory)
 
 	if err := manager.Index(args.Dir); err != nil {
-		log.Fatalln("Index failure")
+		log.Panic("Index failure")
 	}
 
-	log.Infoln("Indexing complete")
+	slog.Info("Indexing complete")
 }

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -1,0 +1,70 @@
+package log
+
+import (
+	"log/slog"
+	"os"
+
+	"gitlab.com/slxh/go/powerline"
+)
+
+// Level contains the application log level.
+var Level slog.LevelVar
+
+var colors = map[slog.Level]powerline.ColorScheme{
+	slog.LevelDebug: {
+		Time:    powerline.NewColor(99, powerline.ColorBlack),
+		Level:   powerline.NewColor(powerline.ColorBlack, 99),
+		Message: powerline.NewColor(99, powerline.ColorDefault),
+	},
+	slog.LevelInfo: {
+		Time:    powerline.NewColor(45, powerline.ColorBlack),
+		Level:   powerline.NewColor(powerline.ColorBlack, 45),
+		Message: powerline.NewColor(45, powerline.ColorDefault),
+	},
+	slog.LevelWarn: {
+		Time:    powerline.NewColor(220, powerline.ColorBlack),
+		Level:   powerline.NewColor(powerline.ColorBlack, 220),
+		Message: powerline.NewColor(220, powerline.ColorDefault),
+	},
+	slog.LevelError: {
+		Time:    powerline.NewColor(208, powerline.ColorBlack),
+		Level:   powerline.NewColor(powerline.ColorBlack, 208),
+		Message: powerline.NewColor(208, powerline.ColorDefault),
+	},
+}
+
+func setLogger(h slog.Handler) {
+	slog.SetDefault(slog.New(h))
+}
+
+func onTTY() bool {
+	s, _ := os.Stdout.Stat()
+
+	return s.Mode()&os.ModeCharDevice > 0
+}
+
+func SetColoredLogger() {
+	setLogger(powerline.NewHandler(os.Stdout, &powerline.HandlerOptions{
+		Level:  &Level,
+		Colors: colors,
+	}))
+}
+
+func SetUncoloredLogger() {
+	setLogger(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: &Level,
+	}))
+}
+
+func SetLogger() {
+	if onTTY() {
+		SetColoredLogger()
+	} else {
+		SetUncoloredLogger()
+	}
+}
+
+func Panic(msg string, args ...any) {
+	slog.Error(msg, args...)
+	panic(msg)
+}

--- a/cli/update.go
+++ b/cli/update.go
@@ -19,14 +19,13 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/DataDrake/cli-ng/v2/cmd"
-	log "github.com/DataDrake/waterlog"
-	"github.com/DataDrake/waterlog/format"
-	"github.com/DataDrake/waterlog/level"
 
 	"github.com/getsolus/solbuild/builder"
+	"github.com/getsolus/solbuild/cli/log"
 )
 
 func init() {
@@ -45,22 +44,22 @@ var Update = cmd.Sub{
 func UpdateRun(r *cmd.Root, c *cmd.Sub) {
 	rFlags := r.Flags.(*GlobalFlags) //nolint:forcetypeassert // guaranteed by callee.
 	if rFlags.Debug {
-		log.SetLevel(level.Debug)
+		log.Level.Set(slog.LevelDebug)
 	}
 
 	if rFlags.NoColor {
-		log.SetFormat(format.Un)
+		log.SetUncoloredLogger()
 	}
 
 	if os.Geteuid() != 0 {
-		log.Fatalln("You must be root to run init profiles")
+		log.Panic("You must be root to run init profiles")
 	}
 	// Initialise the build manager
 	manager, err := builder.NewManager()
 	if err != nil {
-		log.Fatalln(err.Error())
+		log.Panic(err.Error())
 	}
-	// Safety first..
+	// Safety first...
 	if err = manager.SetProfile(rFlags.Profile); err != nil {
 		if errors.Is(err, builder.ErrProfileNotInstalled) {
 			fmt.Fprintf(os.Stderr, "%v: Did you forget to init?\n", err)

--- a/go.mod
+++ b/go.mod
@@ -1,23 +1,25 @@
 module github.com/getsolus/solbuild
 
-go 1.21
+go 1.21.0
+
+toolchain go1.21.1
 
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/DataDrake/cli-ng/v2 v2.0.2
-	github.com/DataDrake/waterlog v1.2.0
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cheggaaa/pb/v3 v3.1.4
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/getsolus/libosdev v0.0.0-20181023041421-9ab0f4b463fd
+	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.9.0
+	gitlab.com/slxh/go/powerline v0.1.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/DataDrake/flair v0.5.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
@@ -27,7 +29,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,6 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/DataDrake/cli-ng/v2 v2.0.2 h1:7+25l25VmlERCE95glW6QKBUF13vxqAM2jasFiN02xQ=
 github.com/DataDrake/cli-ng/v2 v2.0.2/go.mod h1:bU9YaNNWWVq0eIdDsU3TCe9+7Jb398iBBoqee5EiKWQ=
-github.com/DataDrake/flair v0.5.1 h1:JHWOoBRiQGWg+k2bV2Mje2YmDtRjhMj51yDxQkzidWI=
-github.com/DataDrake/flair v0.5.1/go.mod h1:3KgdmkL8eJDbg/HdMwlHkeYH/mpSy/hsQvxYQFp9A/Y=
-github.com/DataDrake/waterlog v1.2.0 h1:T3Hs0D6YOQfz6GtViw+fYSIGpGimU41FubcxQQzaeHM=
-github.com/DataDrake/waterlog v1.2.0/go.mod h1:xSKEWChL8698jwSJSyjKPIpFpj/K5n+Eif2ztYXDjJI=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
@@ -108,6 +104,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+gitlab.com/slxh/go/powerline v0.1.0 h1:/3lwpGRD5yW9HFS/hammtCI4kvtjKw8E1dcpHS9Udx8=
+gitlab.com/slxh/go/powerline v0.1.0/go.mod h1:vBTN83xoDyGejdTeZkMGs8l/qZvOjpUkRMYrthNhqJE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/main.go
+++ b/main.go
@@ -17,22 +17,24 @@
 package main
 
 import (
-	log2 "log"
-
-	log "github.com/DataDrake/waterlog"
-	"github.com/DataDrake/waterlog/format"
-	"github.com/DataDrake/waterlog/level"
+	"os"
 
 	_ "github.com/getsolus/solbuild/builder"
 	"github.com/getsolus/solbuild/cli"
+	"github.com/getsolus/solbuild/cli/log"
 )
 
-func init() {
-	log.SetFormat(format.Min)
-	log.SetLevel(level.Info)
-	log.SetFlags(log2.Ltime | log2.Ldate | log2.LUTC)
+func exit() {
+	if r := recover(); r != nil {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
 }
 
 func main() {
+	defer exit()
+
+	log.SetLogger()
 	cli.Root.Run()
 }


### PR DESCRIPTION
Replace waterlog by `log/slog` now that it's in the standard library.
The output should be similar when using a TTY but log friendly when not.