### PR TITLE
Enable configuration of whether or not to generate history

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -28,6 +28,7 @@ import (
 // Config defines the global defaults for solbuild.
 type Config struct {
 	DefaultProfile string `toml:"default_profile"`  // Name of the default profile to use
+	EnableHistory  bool   `toml:"enable_history"`   // Whether to enable history generation or not
 	EnableTmpfs    bool   `toml:"enable_tmpfs"`     // Whether to enable tmpfs builds or
 	OverlayRootDir string `toml:"overlay_root_dir"` // Custom Overlay Root Dir
 	TmpfsSize      string `toml:"tmpfs_size"`       // Bounding size on the tmpfs
@@ -50,6 +51,7 @@ func NewConfig() (*Config, error) {
 	// Set up some sane defaults just in case someone mangles the configs
 	config := &Config{
 		DefaultProfile: "main-x86_64",
+		EnableHistory:  false,
 		EnableTmpfs:    false,
 		OverlayRootDir: "/var/cache/solbuild",
 		TmpfsSize:      "",

--- a/builder/manager.go
+++ b/builder/manager.go
@@ -187,21 +187,25 @@ func (m *Manager) SetPackage(pkg *Package) error {
 		return ErrProfileNotInstalled
 	}
 
-	// Obtain package history for git builds
-	if pkg.Type == PackageTypeYpkg {
-		repo, err := git.PlainOpenWithOptions(filepath.Dir(pkg.Path),
-			&git.PlainOpenOptions{DetectDotGit: true})
-		if err != nil && !errors.Is(err, git.ErrRepositoryNotExists) {
-			return fmt.Errorf("cannot open Git repository: %w", err)
-		}
+	if m.Config.EnableHistory {
+		slog.Info("History generation enabled")
 
-		if err == nil {
-			if history, err := NewPackageHistory(repo, pkg.Path); err == nil {
-				slog.Debug("Obtained package history")
+		// Obtain package history for git builds
+		if pkg.Type == PackageTypeYpkg {
+			repo, err := git.PlainOpenWithOptions(filepath.Dir(pkg.Path),
+				&git.PlainOpenOptions{DetectDotGit: true})
+			if err != nil && !errors.Is(err, git.ErrRepositoryNotExists) {
+				return fmt.Errorf("cannot open Git repository: %w", err)
+			}
 
-				m.history = history
-			} else {
-				slog.Warn("Failed to obtain package git history", "err", err)
+			if err == nil {
+				if history, err := NewPackageHistory(repo, pkg.Path); err == nil {
+					slog.Debug("Obtained package history")
+
+					m.history = history
+				} else {
+					slog.Warn("Failed to obtain package git history", "err", err)
+				}
 			}
 		}
 	}

--- a/cli/build.go
+++ b/cli/build.go
@@ -51,6 +51,7 @@ type BuildFlags struct {
 	Memory          string `short:"m" long:"memory"             desc:"Set the tmpfs size to use, e.g. 8G"`
 	TransitManifest string `          long:"transit-manifest"   desc:"Create transit manifest for the given target"`
 	ABIReport       bool   `short:"r" long:"disable-abi-report" desc:"Don't generate an ABI report of the completed build"`
+	History         bool   `short:"h" long:"history"            desc:"Enable history generation for this build"`
 }
 
 // BuildArgs are arguments for the "build" sub-command.
@@ -103,6 +104,11 @@ func BuildRun(r *cmd.Root, s *cmd.Sub) {
 	// Safety first...
 	if err = manager.SetProfile(rFlags.Profile); err != nil {
 		os.Exit(1)
+	}
+
+	// Enable history generation
+	if sFlags.History {
+		manager.Config.EnableHistory = true
 	}
 
 	pkg, err := builder.NewPackage(pkgPath)

--- a/data/00_solbuild.conf
+++ b/data/00_solbuild.conf
@@ -10,6 +10,10 @@
 # "-p" profile argument to solbuild
 default_profile = "main-x86_64"
 
+# Setting this to true will enable package history generation
+# Note you can still override this at runtime with the -h flag
+enable_history = false
+
 # Setting this to true will default the builder to using tmpfs
 # Note you can still override this at runtime with the -t flag
 enable_tmpfs = false


### PR DESCRIPTION
This adds the flag `-h` (long form `--history`) which enables history generation. It is also possible to set a config item for this.