### PR TITLE
builder/source/simple: Disable compression when downloading artifacts

### DIFF
--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -137,7 +138,17 @@ func (s *SimpleSource) download(destination string) error {
 		req.SetChecksum(sha256.New(), sum, false)
 	}
 
-	resp := grab.NewClient().Do(req)
+	// Keep go-grab defaults but also disable compression
+	// https://github.com/cavaliergopher/grab/blob/v3.0.1/v3/client.go#L53
+	tr := &http.Transport{
+		DisableCompression: true,
+		Proxy:              http.ProxyFromEnvironment,
+	}
+
+	client := grab.NewClient()
+	client.HTTPClient = &http.Client{Transport: tr}
+
+	resp := client.Do(req)
 
 	// Setup our progress bar
 	pbar := pb.Start64(resp.Size())

--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -138,15 +138,17 @@ func (s *SimpleSource) download(destination string) error {
 		req.SetChecksum(sha256.New(), sum, false)
 	}
 
-	// Keep go-grab defaults but also disable compression
-	// https://github.com/cavaliergopher/grab/blob/v3.0.1/v3/client.go#L53
-	tr := &http.Transport{
-		DisableCompression: true,
-		Proxy:              http.ProxyFromEnvironment,
+	// Create a client with compression disabled.
+	// See: https://github.com/cavaliergopher/grab/blob/v3.0.1/v3/client.go#L53
+	client := &grab.Client{
+		UserAgent: "solbuild",
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				DisableCompression: true,
+				Proxy:              http.ProxyFromEnvironment,
+			},
+		},
 	}
-
-	client := grab.NewClient()
-	client.HTTPClient = &http.Client{Transport: tr}
 
 	resp := client.Do(req)
 


### PR DESCRIPTION
Generally causing more issues than it solves. It's usefulness is also pretty debatable when we're downloading pre-compressed artifacts.

Resolves https://github.com/getsolus/packages/issues/989.