### PR TITLE
Add version to User-Agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINNAME := solbuild
 
 .PHONY: build
 build:
-	go build -o bin/$(BINNAME) $(CURDIR)/main.go
+	go build -ldflags "-X github.com/getsolus/solbuild/util.SolbuildVersion=$(VERSION)" -o bin/$(BINNAME) $(CURDIR)/main.go
 
 .PHONY: install
 install:

--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/cheggaaa/pb/v3"
+
+	"github.com/getsolus/solbuild/util"
 )
 
 const progressBarTemplate string = `{{with string . "prefix"}}{{.}} {{end}}{{printf "%25s" (counters .) }} {{bar . }} {{printf "%7s" (percent .) }} {{printf "%14s" (speed . "%s/s" "??/s")}}{{with string . "suffix"}} {{.}}{{end}}`
@@ -141,7 +143,7 @@ func (s *SimpleSource) download(destination string) error {
 	// Create a client with compression disabled.
 	// See: https://github.com/cavaliergopher/grab/blob/v3.0.1/v3/client.go#L53
 	client := &grab.Client{
-		UserAgent: "solbuild",
+		UserAgent: "solbuild/" + util.SolbuildVersion,
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
 				DisableCompression: true,

--- a/cli/version.go
+++ b/cli/version.go
@@ -20,11 +20,8 @@ import (
 	"fmt"
 
 	"github.com/DataDrake/cli-ng/v2/cmd"
-)
 
-const (
-	// SolbuildVersion is the current public version of solbuild.
-	SolbuildVersion = "1.5.3.0"
+	"github.com/getsolus/solbuild/util"
 )
 
 func init() {
@@ -42,6 +39,6 @@ var Version = cmd.Sub{
 //
 //nolint:forbidigo // the point of this function is to print the version
 func VersionRun(_ *cmd.Root, _ *cmd.Sub) {
-	fmt.Printf("solbuild version %v\n\nCopyright © 2016-2021 Solus Project\n", SolbuildVersion)
+	fmt.Printf("solbuild version %v\n\nCopyright © 2016-2021 Solus Project\n", util.SolbuildVersion)
 	fmt.Println("Licensed under the Apache License, Version 2.0")
 }

--- a/util/version.go
+++ b/util/version.go
@@ -1,0 +1,19 @@
+//
+// Copyright © 2016-2021 Solus Project <copyright@getsol.us>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+var SolbuildVersion = "development"


### PR DESCRIPTION
The [HTTP User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) specification requires that the user-agent has a version in it. Let's add this to hopefully improve success of this client with HTTP servers that require it.

Also, since we now reference the version from multiple places let's move configuration of it to the makefile and not have to duplicate references to it. Create a util package to avoid having to introduce a circular dependency (or to have it in the source package where it doesn't make sense)