### PR TITLE
Add Accept header to HTTP requests

### DIFF
--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -128,6 +128,9 @@ func (s *SimpleSource) download(destination string) error {
 		return err
 	}
 
+	// Indicate that we will accept any response content-type. Some servers will fail without this (like netfilter.org)
+	req.HTTPRequest.Header.Add("Accept", `*/*`)
+
 	// Ensure the checksum matches
 	if !s.legacy {
 		sum, err := hex.DecodeString(s.validator)


### PR DESCRIPTION
While debugging why netfilter.org was returning a 403 with the Solbuild client I noticed that wget (which succeeded) was sending the `Accept: */*` header. When I added it to Solbuild it started working. This header should be safe to send in all circumstances as it merely indicates that we're willing to accept any content-type (which we are).