### PR TITLE
Redirect child processes' stderr to the parent stdout

### DIFF
--- a/builder/chroot.go
+++ b/builder/chroot.go
@@ -24,6 +24,10 @@ import (
 	"github.com/getsolus/libosdev/commands"
 )
 
+func init() {
+	commands.SetStderr(os.Stdout)
+}
+
 // Chroot will attempt to spawn a chroot in the overlayfs system.
 func (p *Package) Chroot(notif PidNotifier, pman *EopkgManager, overlay *Overlay) error {
 	slog.Debug("Beginning chroot", "profile", overlay.Back.Name, "version", p.Version,

--- a/builder/util.go
+++ b/builder/util.go
@@ -192,7 +192,7 @@ func ChrootExec(notif PidNotifier, dir, command string) error {
 	args := []string{dir, "/bin/sh", "-c", command}
 	c := exec.Command("chroot", args...)
 	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	c.Stderr = os.Stdout
 	c.Stdin = nil
 	c.Env = ChrootEnvironment
 	c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
@@ -212,7 +212,7 @@ func ChrootExecStdin(notif PidNotifier, dir, command string) error {
 	args := []string{dir, "/bin/sh", "-c", command}
 	c := exec.Command("chroot", args...)
 	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	c.Stderr = os.Stdout
 	c.Stdin = os.Stdin
 	c.Env = ChrootEnvironment
 

--- a/cli/init.go
+++ b/cli/init.go
@@ -33,6 +33,7 @@ import (
 )
 
 func init() {
+	commands.SetStderr(os.Stdout)
 	cmd.Register(&Init)
 	cmd.Register(&cmd.Help)
 }


### PR DESCRIPTION
We want to do this to log all lines printed by child processes. Sometimes solbuild builds big packages that may take hours; it's handy to fire it and let it work and check the output later. E.g.:

    sudo solbuild build > log.txt

Fixes #54.