### PR TITLE
init: Use multithreaded xz decompression (-T0)

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -115,7 +115,7 @@ func doInit(manager *builder.Manager) {
 	// Decompress the image
 	slog.Debug("Decompressing backing image", "source", bk.ImagePathXZ, "target", bk.ImagePath)
 
-	if err := commands.ExecStdoutArgsDir(builder.ImagesDir, "unxz", []string{bk.ImagePathXZ}); err != nil {
+	if err := commands.ExecStdoutArgsDir(builder.ImagesDir, "unxz", []string{"-T0", bk.ImagePathXZ}); err != nil {
 		slog.Error("Failed to decompress image", "source", bk.ImagePathXZ, "err", err)
 		panic(err)
 	}


### PR DESCRIPTION
On my AMD Ryzen R7 2700X, unxz of a ~260MiB unstable .img.xz takes 30s. In comparison, unxz -T0 of the same ~260MiB unstable .img.xz takes 4s.

According to the xz release notes, multithreaded compression has been supported since xz version 5.2.0, which was released in 2014.

xz 5.2.2 was added to the Solus repos in October 2016, so all Solus installs since then would have supported multi-threaded decompression, making the addition of the -T0 flag in solbuild guaranteed to work on existing systems.

The end result is a nicer user experience when updating solbuild images.