### PR TITLE
Direct log output to stderr and hide progress bar when redirected

### DIFF
--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -197,6 +197,7 @@ func (s *SimpleSource) download(destination string) error {
 	pbar := pb.Start64(resp.Size())
 	pbar.Set(pb.Bytes, true)
 	pbar.SetTemplateString(progressBarTemplate)
+	pbar.SetWriter(os.Stdout)
 
 	defer pbar.Finish()
 

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -38,20 +38,20 @@ func setLogger(h slog.Handler) {
 }
 
 func onTTY() bool {
-	s, _ := os.Stdout.Stat()
+	s, _ := os.Stderr.Stat()
 
 	return s.Mode()&os.ModeCharDevice > 0
 }
 
 func SetColoredLogger() {
-	setLogger(powerline.NewHandler(os.Stdout, &powerline.HandlerOptions{
+	setLogger(powerline.NewHandler(os.Stderr, &powerline.HandlerOptions{
 		Level:  &Level,
 		Colors: colors,
 	}))
 }
 
 func SetUncoloredLogger() {
-	setLogger(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+	setLogger(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: &Level,
 	}))
 }


### PR DESCRIPTION
After this change it is possible to differentiate between the log output from solbuild itself, and the output from commands executed by solbuild. This allows one to check the build result on the terminal and keep the redirected stdout for checking the reason for the build result. This is a follow-up of #54/#63.

Additionally, the progress bar is replaced by a log statement when redirected.

For example:

```
$ sudo solbuild build package.yml -p unstable-x86_64 > /tmp/output.log
 ✓ > Downloading source uri=https://www.nano-editor.org/dist/v7/nano-7.2.tar.xz
 ✓ > Now starting build package=nano
 ✓ > Building succeeded
```
