### PR TITLE
Add RELEASE.md integration and release testing doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /pkg/
+solbuild

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
+# Solbuild Release Engineering Checklist
+
 Perform the following steps after tagging the Solbuild release in order to verify that it introduces no major regressions:
 
-- Build and install a local update of the solbuild package:
+- Build and install a local update of the solbuild package corresponding to the newly tagged release:
   ```
   gotosoluspkgs
   gotopkg solbuild
@@ -24,7 +26,7 @@ Perform the following steps after tagging the Solbuild release in order to verif
   ```
   sudo solbuild init -du
   ```
-  Verify that this uses the unstable profile.
+  Verify that this uses the unstable profile and shows debug output.
 
 - Initialise Shannon profile:
   ```
@@ -51,7 +53,7 @@ Perform the following steps after tagging the Solbuild release in order to verif
 - Build zlib against unstable and copy to local repo:
   ```
   sudo solbuild build -d
-  sudo cp zlib*.eopkg /var/lib/solbuild/local/
+  sudo cp -v zlib*.eopkg /var/lib/solbuild/local/
   ```
 
 - Index the local repo:
@@ -59,7 +61,7 @@ Perform the following steps after tagging the Solbuild release in order to verif
   sudo solbuild index -d /var/lib/solbuild/local/
   ```
 
-- Build the test set of packages:
+- Build the recommended test set of packages, which exercises problematic SourceForget URIs and git submodule functionality:
   ```
   for p in android-tools giflib glew zsh
   do

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,70 @@
+Perform the following steps after tagging the Solbuild release in order to verify that it introduces no major regressions:
+
+- Build and install a local update of the solbuild package:
+  ```
+  gotosoluspkgs
+  gotopkg solbuild
+  yupdate X.Y.Z https://github.com/getsolus/solbuild/archive/refs/tags/vX.Y.Z.tar.gz
+  go-task
+  sudo eopkg it *.eopkg
+  ```
+
+- Ensure the version number is correct:
+  ```
+  solbuild version
+  ```
+  Verify that this shows the correct version number.
+
+- Delete cache and existing solbuild images:
+  ```
+  sudo solbuild dc -dai
+  ```
+
+- Initialise unstable profile:
+  ```
+  sudo solbuild init -du
+  ```
+  Verify that this uses the unstable profile.
+
+- Initialise Shannon profile:
+  ```
+  sudo solbuild init -nup main-x86_64
+  ```
+  Verify that this shows non-colored output.
+
+- Delete local repo:
+  ```
+  sudo rm -rvf /var/lib/solbuild/local/*
+  ```
+- Build `zlib` against stable without colored output:
+  ```
+  gotosoluspkgs
+  gotopkg zlib
+  sudo solbuild build -n -p main-x86_64 > zlib-stable.log
+  ```
+  Verify that this shows non-colored output.
+
+- Chroot into the build environment:
+  ```
+  sudo solbuild -d -n chroot -p main-x86_64
+  ```
+- Build zlib against unstable and copy to local repo:
+  ```
+  sudo solbuild build -d
+  sudo cp zlib*.eopkg /var/lib/solbuild/local/
+  ```
+
+- Index the local repo:
+  ```
+  sudo solbuild index -d /var/lib/solbuild/local/
+  ```
+
+- Build the test set of packages:
+  ```
+  for p in android-tools giflib glew zsh
+  do
+    sudo solbuild build >> /tmp/builds.log
+  done
+  ```
+
+If all of the above completes successfully, proceed to `go-task publish` the Solbuild update.


### PR DESCRIPTION
The intent is for us to have a uniform and rigorous release testing process to minimise the chances of bad releases sneaking into production.

Also add `solbuild` to .gitignore