### PR TITLE
Replace `delete-cache --sizes` by `show-cache`

### DIFF
--- a/cli/delete_cache.go
+++ b/cli/delete_cache.go
@@ -48,7 +48,7 @@ var DeleteCache = cmd.Sub{
 type DeleteCacheFlags struct {
 	All    bool `short:"a" long:"all"    desc:"Additionally delete (s)ccache, packages and sources"`
 	Images bool `short:"i" long:"images" desc:"Additionally delete solbuild images"`
-	Sizes  bool `short:"s" long:"sizes"  desc:"Show disk usage of the caches"`
+	Sizes  bool `short:"s" long:"sizes"  desc:"Deprecated: use 'show-cache' instead"`
 }
 
 // DeleteCacheRun carries out the "delete-cache" sub-command.
@@ -75,31 +75,7 @@ func DeleteCacheRun(r *cmd.Root, s *cmd.Sub) {
 
 	// If sizes is requested just print disk usage of caches and return
 	if sFlags.Sizes {
-		sizeDirs := []string{
-			manager.Config.OverlayRootDir,
-			builder.CacheDirectory,
-			builder.ObsoleteCcacheDirectory,
-			builder.ObsoleteSccacheDirectory,
-			builder.ObsoleteLegacyCcacheDirectory,
-			builder.ObsoleteLegacySccacheDirectory,
-			builder.PackageCacheDirectory,
-			source.SourceDir,
-		}
-
-		var totalSize int64
-
-		for _, p := range sizeDirs {
-			size, _ := getDirSize(p)
-			totalSize += size
-
-			if err != nil {
-				slog.Warn("Couldn't get directory size", "reason", err)
-			}
-
-			slog.Info(fmt.Sprintf("Size of '%s' is '%s'", p, humanReadableFormat(float64(size))))
-		}
-
-		slog.Info(fmt.Sprintf("Total size: '%s'", humanReadableFormat(float64(totalSize))))
+		showCacheSizes(manager)
 
 		return
 	}

--- a/cli/show_cache.go
+++ b/cli/show_cache.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/DataDrake/cli-ng/v2/cmd"
+
+	"github.com/getsolus/solbuild/builder"
+	"github.com/getsolus/solbuild/builder/source"
+	"github.com/getsolus/solbuild/cli/log"
+)
+
+func init() {
+	cmd.Register(&ShowCache)
+}
+
+// ShowCache shows the disk usage of the solbuild cache.
+var ShowCache = cmd.Sub{
+	Name:  "show-cache",
+	Alias: "sc",
+	Short: "Show the size of assets stored on disk by solbuild",
+	Run:   ShowCacheRun,
+}
+
+func ShowCacheRun(r *cmd.Root, s *cmd.Sub) {
+	rFlags := r.Flags.(*GlobalFlags) //nolint:forcetypeassert // guaranteed by callee.
+
+	if rFlags.Debug {
+		log.Level.Set(slog.LevelDebug)
+	}
+
+	if rFlags.NoColor {
+		log.SetUncoloredLogger()
+	}
+
+	manager, err := builder.NewManager()
+	if err != nil {
+		log.Panic("Failed to create new Manager: %e\n", err)
+	}
+
+	showCacheSizes(manager)
+}
+
+func showCacheSizes(manager *builder.Manager) {
+	sizeDirs := []string{
+		manager.Config.OverlayRootDir,
+		builder.CacheDirectory,
+		builder.ObsoleteCcacheDirectory,
+		builder.ObsoleteSccacheDirectory,
+		builder.ObsoleteLegacyCcacheDirectory,
+		builder.ObsoleteLegacySccacheDirectory,
+		builder.PackageCacheDirectory,
+		source.SourceDir,
+	}
+
+	var totalSize int64
+
+	for _, p := range sizeDirs {
+		size, err := getDirSize(p)
+		totalSize += size
+
+		if err != nil {
+			slog.Warn("Couldn't get directory size", "reason", err)
+		}
+
+		slog.Info(fmt.Sprintf("Size of '%s' is '%s'", p, humanReadableFormat(float64(size))))
+	}
+
+	slog.Info(fmt.Sprintf("Total size: '%s'", humanReadableFormat(float64(totalSize))))
+}


### PR DESCRIPTION
The `--sizes` flag for `delete-cache` is confusing as it makes the command not actually delete sizes.

Deprecate the confusing flag, and add a new command to replace it: `show-cache`.

Resolves #80