### PR TITLE
Bring back support for file:// sources

### DIFF
--- a/builder/source/file.go
+++ b/builder/source/file.go
@@ -1,0 +1,37 @@
+package source
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+)
+
+const (
+	dstFileMode  = 0o644
+	dstFileFlags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+)
+
+// IsFileURI returns true if the given URI is a file:// URI.
+func IsFileURI(uri *url.URL) bool {
+	return uri.Scheme == "file"
+}
+
+// CopyFile copies a file.
+func CopyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("unable to open source file: %w", err)
+	}
+
+	dstFile, err := os.OpenFile(dst, dstFileFlags, dstFileMode)
+	if err != nil {
+		return fmt.Errorf("unable to open destination file: %w", err)
+	}
+
+	if _, err = io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("unable to copy file contents: %w", err)
+	}
+
+	return nil
+}

--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -126,6 +126,10 @@ func (s *SimpleSource) IsFetched() bool {
 
 // download downloads simple files using go grab.
 func (s *SimpleSource) download(destination string) error {
+	if IsFileURI(s.url) {
+		return CopyFile(s.url.Path, destination)
+	}
+
 	// Some web servers (*cough* sourceforge) have strange redirection behavior. It's possible to work around this by clearing the Referer header on every redirect
 	headHttpClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
Solbuild 1.5.3.0 replace the way files are downloaded. The feature to download files using `file://` sources was lost.

Restore the functionality to set sources using `file://` by copying the file when encountered.

Resolves #38.