### PR TITLE
Start sccache server when ccache is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.6.1
+VERSION := 1.6.2
 BINNAME := solbuild
 
 .PHONY: build

--- a/builder/build.go
+++ b/builder/build.go
@@ -335,6 +335,11 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 		cmd += fmt.Sprintf(" -t %v", h.GetLastVersionTimestamp())
 	}
 
+	if p.CanCCache {
+		// Start an sccache server to work around #87
+		StartSccache(overlay.MountPoint)
+	}
+
 	slog.Info("Now starting build", "package", p.Name)
 
 	if err := ChrootExec(notif, overlay.MountPoint, cmd); err != nil {

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -279,7 +279,6 @@ func readURIFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	defer fi.Close()
 
 	contents, err := io.ReadAll(fi)

--- a/builder/pkg.go
+++ b/builder/pkg.go
@@ -62,6 +62,7 @@ type Package struct {
 	Path       string          // Path to the build spec
 	Sources    []source.Source // Each package has 0 or more sources that we fetch
 	CanNetwork bool            // Only applicable to ypkg builds
+	CanCCache  bool            // Flag to enable (s)ccache
 }
 
 // YmlPackage is a parsed ypkg build file.
@@ -71,6 +72,9 @@ type YmlPackage struct {
 	Release    int                 `yaml:"release"`
 	Networking bool                `yaml:"networking"` // If set to false (default) we disable networking in the build
 	Source     []map[string]string `yaml:"source"`
+
+	// Disable (s)ccache for this build.
+	CCache bool `yaml:"ccache"`
 }
 
 // XMLUpdate represents an update in the package history.
@@ -209,7 +213,7 @@ func NewYmlPackage(path string) (*Package, error) {
 func NewYmlPackageFromBytes(by []byte) (*Package, error) {
 	var err error
 
-	ypkg := &YmlPackage{Networking: false}
+	ypkg := &YmlPackage{Networking: false, CCache: true}
 	if err = yaml.Unmarshal(by, ypkg); err != nil {
 		return nil, err
 	}
@@ -220,6 +224,7 @@ func NewYmlPackageFromBytes(by []byte) (*Package, error) {
 		Release:    ypkg.Release,
 		Type:       PackageTypeYpkg,
 		CanNetwork: ypkg.Networking,
+		CanCCache:  ypkg.CCache,
 	}
 
 	for _, row := range ypkg.Source {


### PR DESCRIPTION
Start the sccache server so it is ready to be used by tools like Cargo. This is a workaround for an issue where builds hang until the sccache server exits, see #87.