### PR TITLE
git: Fix fetch

### DIFF
--- a/builder/source/git.go
+++ b/builder/source/git.go
@@ -115,6 +115,7 @@ func clone(uri, path, ref string) error {
 func reset(path, ref string) error {
 	fetchArgs := []string{
 		"fetch",
+		"--tags",
 		"origin",
 	}
 


### PR DESCRIPTION
We need to add `--tags` to ensure that the remotes tags are updated locally.