### PR TITLE
builder: Use eopkg.py3 to build pspec.xml recipes

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -382,7 +382,7 @@ func (p *Package) BuildXML(notif PidNotifier, pman *EopkgManager, overlay *Overl
 
 	// Now build the package, ignore-sandbox in case someone is stupid
 	// and activates it in eopkg.conf...
-	cmd := eopkgCommand(fmt.Sprintf("eopkg build --ignore-sandbox --yes-all -O %s %s", wdir, xmlFile))
+	cmd := eopkgCommand(fmt.Sprintf("eopkg.py3 build --ignore-sandbox --yes-all -O %s %s", wdir, xmlFile))
 
 	slog.Info("Now starting build", "package", p.Name)
 

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -219,7 +219,7 @@ func (e *EopkgManager) Upgrade() error {
 
 // InstallComponent will install the named component inside the chroot.
 func (e *EopkgManager) InstallComponent(comp string) error {
-	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg install -c %v -y", comp)))
+	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg install -y -c %v", comp)))
 	e.notif.SetActivePID(0)
 
 	return err


### PR DESCRIPTION
This ensures that solbuild will work with the phase1+2 changes to eopkg and pisi packages [here](https://github.com/getsolus/packages/pull/2964)

In addition, make a cosmetic tweak to eopkg install commands (which will effectively be using eopkg.bin when the PR above lands) so the -y flag is set before the -c flag when installing components.