### PR TITLE
Experiment with using rootlesskit instead of fakeroot + native solbuild container/network code

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -338,7 +338,7 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 	}
 
 	// need to properly quote the innner -c 'command' syntax
-	suCmd := fmt.Sprintf("strace /bin/su %s --command='%s'", BuildUser, buildCmd)
+	//suCmd := fmt.Sprintf("strace /bin/su %s --command='%s'", BuildUser, buildCmd)
 
 	if p.CanCCache {
 		// Start an sccache server to work around #87
@@ -352,9 +352,9 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 	}
 
 	slog.Info("Now starting build", "package", p.Name)
-	slog.Info("Build", "command", suCmd)
+	slog.Info("Build", "command", buildCmd)
 
-	if err := RootlesskitExec(notif, overlay.MountPoint, suCmd); err != nil {
+	if err := RootlesskitExec(notif, overlay.MountPoint, buildCmd); err != nil {
 		return fmt.Errorf("Failed to start build of package, reason: %w\n", err)
 	}
 

--- a/builder/build.go
+++ b/builder/build.go
@@ -326,7 +326,9 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 	ymlFile := filepath.Join(wdir, filepath.Base(p.Path))
 
 	// Now build the package
-	cmd := fmt.Sprintf("/bin/su %s -- fakeroot ypkg-build -D %s %s", BuildUser, wdir, ymlFile)
+	// cmd := fmt.Sprintf("/bin/su %s -- fakeroot ypkg-build -D %s %s", BuildUser, wdir, ymlFile)
+	// use rootlesskit instead of fatfakeroot
+	cmd := fmt.Sprintf("/bin/su %s -- rootlesskit ypkg-build -D %s %s", BuildUser, wdir, ymlFile)
 	if DisableColors {
 		cmd += " -n"
 	}

--- a/builder/namespaces.go
+++ b/builder/namespaces.go
@@ -17,9 +17,9 @@
 package builder
 
 import (
-	"fmt"
+	//"fmt"
 	"log/slog"
-	"syscall"
+	//"syscall"
 )
 
 // ConfigureNamespace will unshare() context, entering a new namespace.

--- a/builder/namespaces.go
+++ b/builder/namespaces.go
@@ -26,9 +26,9 @@ import (
 func ConfigureNamespace() error {
 	slog.Debug("Configuring container namespace")
 
-	if err := syscall.Unshare(syscall.CLONE_NEWNS | syscall.CLONE_NEWIPC); err != nil {
-		return fmt.Errorf("Failed to configure namespace, reason: %w\n", err)
-	}
+	// if err := syscall.Unshare(syscall.CLONE_NEWNS | syscall.CLONE_NEWIPC); err != nil {
+	//	return fmt.Errorf("Failed to configure namespace, reason: %w\n", err)
+	// }
 
 	return nil
 }
@@ -37,9 +37,9 @@ func ConfigureNamespace() error {
 func DropNetworking() error {
 	slog.Debug("Dropping container networking")
 
-	if err := syscall.Unshare(syscall.CLONE_NEWNET | syscall.CLONE_NEWUTS); err != nil {
-		return fmt.Errorf("Failed to drop networking capabilities, reason: %w\n", err)
-	}
+	// if err := syscall.Unshare(syscall.CLONE_NEWNET | syscall.CLONE_NEWUTS); err != nil {
+	//	return fmt.Errorf("Failed to drop networking capabilities, reason: %w\n", err)
+	// }
 
 	return nil
 }

--- a/builder/util.go
+++ b/builder/util.go
@@ -212,7 +212,8 @@ func ChrootExec(notif PidNotifier, dir, command string) error {
 // using the 'solbuild' user (expected to exist a priori and have /etc/sub{g,u}id files),
 // such that we can store the PID for long running tasks.
 func RootlesskitExec(notif PidNotifier, dir, command string) error {
-	rootlesskitCmd := fmt.Sprintf("-c rootlesskit chroot %s %s", dir, command)
+	rootlesskitCmd := fmt.Sprintf(
+		"-c rootlesskit --copy-up=/var/cache/eopkg/archives chroot %s %s", dir, command)
 	args := []string{"solbuild", rootlesskitCmd}
 	c := exec.Command("/bin/su", args...)
 	c.Stdout = os.Stdout


### PR DESCRIPTION
Just for the heck of it, this PoC PR disables the native solbuild namespace and networking setup, and calls ypkg via a rootlesskit chroot invocation directly instead of calling fakeroot as the 'build' user in a solbuild managed container.

This commit assumes the a priori existence of the solbuild user/group on the host system and assumes that this user has been set up with subuids and subgids.

NB: The current draft does not support networking (but rootlesskit has facilities for turning it on).

To enable networking support, the build command will need to be something like `rootlesskit --net=slirp4netns --copy-up=/etc --disable-host-loopback ypkg-build (...)`.

This implies that the build executable command could perhaps be set from builder/manager.go (which is where networking is enabled currently).

Current status (as of e128f7ed0c1a17354cf04d75091798a8d238d7fb):

![rootlesskit-chroot-ypkg-build](https://github.com/user-attachments/assets/1c346a3c-7ce4-4899-8fa5-7bd62f996619)
