### PR TITLE
builder: Don't use fakeroot

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -322,11 +322,12 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 		return err
 	}
 
-	wdir := p.GetWorkDirInternal()
-	ymlFile := filepath.Join(wdir, filepath.Base(p.Path))
+	workDir := p.GetWorkDirInternal()
+	ymlFile := filepath.Join(workDir, filepath.Base(p.Path))
+	buildDir := filepath.Join(BuildUserHome, "YPKG")
 
 	// Now build the package
-	cmd := fmt.Sprintf("/bin/su %s -- fakeroot ypkg-build -D %s %s", BuildUser, wdir, ymlFile)
+	cmd := fmt.Sprintf("ypkg-build -D %s -B %s %s", workDir, buildDir, ymlFile)
 	if DisableColors {
 		cmd += " -n"
 	}

--- a/builder/chroot.go
+++ b/builder/chroot.go
@@ -66,14 +66,8 @@ func (p *Package) Chroot(notif PidNotifier, pman *EopkgManager, overlay *Overlay
 	// Allow bash to work
 	commands.SetStdin(os.Stdin)
 
-	// Legacy package format requires root, stay as root.
-	user := BuildUser
-	if p.Type == PackageTypeXML {
-		user = "root"
-	}
-
-	loginCommand := fmt.Sprintf("/bin/su - %s -s %s", user, BuildUserShell)
-	err := ChrootExecStdin(notif, overlay.MountPoint, loginCommand)
+	loginCommand := fmt.Sprintf("/bin/su - root -s %s", BuildUserShell)
+	err := ChrootShell(notif, overlay.MountPoint, loginCommand, BuildUserHome)
 
 	commands.SetStdin(nil)
 	notif.SetActivePID(0)

--- a/builder/util.go
+++ b/builder/util.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -153,6 +154,8 @@ func SaneEnvironment(username, home string) []string {
 		fmt.Sprintf("HOME=%s", home),
 		fmt.Sprintf("USER=%s", username),
 		fmt.Sprintf("USERNAME=%s", username),
+		fmt.Sprintf("CCACHE_DIR=%s", path.Join(BuildUserHome, ".ccache")),
+		fmt.Sprintf("SCCACHE_DIR=%s", path.Join(BuildUserHome, ".cache", "sccache")),
 	}
 	// Consider an option to even filter these out
 	permitted := []string{

--- a/builder/util.go
+++ b/builder/util.go
@@ -231,7 +231,6 @@ func ChrootExecStdin(notif PidNotifier, dir, command string) error {
 }
 
 func ChrootShell(notif PidNotifier, dir, command, workdir string) error {
-
 	// Hold an fd for the og root
 	fd, err := os.Open("/")
 	if err != nil {
@@ -239,22 +238,22 @@ func ChrootShell(notif PidNotifier, dir, command, workdir string) error {
 	}
 
 	// Remember our working directory
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
+	wd, err2 := os.Getwd()
+	if err2 != nil {
+		return err2
 	}
 
 	// Ensure chroot directory is available
-	if err := os.Chdir(dir); err != nil {
+	if err = os.Chdir(dir); err != nil {
 		return err
 	}
 
-	if err := syscall.Chroot(dir); err != nil {
+	if err = syscall.Chroot(dir); err != nil {
 		fd.Close()
 		return err
 	}
 
-	if err := os.Chdir("/"); err != nil {
+	if err = os.Chdir("/"); err != nil {
 		return err
 	}
 
@@ -267,28 +266,32 @@ func ChrootShell(notif PidNotifier, dir, command, workdir string) error {
 	c.Env = ChrootEnvironment
 	c.Dir = workdir
 
-	if err := c.Start(); err != nil {
+	if err = c.Start(); err != nil {
 		goto CLEANUP
 	}
 
 	notif.SetActivePID(c.Process.Pid)
 
-	if err := c.Wait(); err != nil {
+	if err = c.Wait(); err != nil {
 		goto CLEANUP
 	}
 
 CLEANUP:
 	// Return to our original root and working directory
 	defer fd.Close()
-	if err := fd.Chdir(); err != nil {
+
+	if err = fd.Chdir(); err != nil {
 		return err
 	}
-	if err := syscall.Chroot("."); err != nil {
+
+	if err = syscall.Chroot("."); err != nil {
 		return err
 	}
-	if err := os.Chdir(wd); err != nil {
+
+	if err = os.Chdir(wd); err != nil {
 		return err
 	}
+
 	return err
 }
 

--- a/builder/util.go
+++ b/builder/util.go
@@ -230,6 +230,68 @@ func ChrootExecStdin(notif PidNotifier, dir, command string) error {
 	return c.Wait()
 }
 
+func ChrootShell(notif PidNotifier, dir, command, workdir string) error {
+
+	// Hold an fd for the og root
+	fd, err := os.Open("/")
+	if err != nil {
+		return err
+	}
+
+	// Remember our working directory
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// Ensure chroot directory is available
+	if err := os.Chdir(dir); err != nil {
+		return err
+	}
+
+	if err := syscall.Chroot(dir); err != nil {
+		fd.Close()
+		return err
+	}
+
+	if err := os.Chdir("/"); err != nil {
+		return err
+	}
+
+	// Spawn a shell
+	args := []string{"--login"}
+	c := exec.Command("/bin/bash", args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stdout
+	c.Stdin = os.Stdin
+	c.Env = ChrootEnvironment
+	c.Dir = workdir
+
+	if err := c.Start(); err != nil {
+		goto CLEANUP
+	}
+
+	notif.SetActivePID(c.Process.Pid)
+
+	if err := c.Wait(); err != nil {
+		goto CLEANUP
+	}
+
+CLEANUP:
+	// Return to our original root and working directory
+	defer fd.Close()
+	if err := fd.Chdir(); err != nil {
+		return err
+	}
+	if err := syscall.Chroot("."); err != nil {
+		return err
+	}
+	if err := os.Chdir(wd); err != nil {
+		return err
+	}
+	return err
+}
+
 func StartSccache(dir string) {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
We're inside of a clean rootfs container, we can just build as root, using fakeroot is unnecessary.

Depends on https://github.com/getsolus/ypkg/pull/94

Closes #66 