### PR TITLE
Use nuitka-compiled py3 eopkg.bin (except for when building old-style pspec.xml packages)

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -363,6 +363,7 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 
 // BuildXML will take care of building the legacy pspec.xml format, and is called only
 // by Build().
+// NOTE: Change eopkgCommand to use eopkg.py3 for epoch.
 func (p *Package) BuildXML(notif PidNotifier, pman *EopkgManager, overlay *Overlay) error {
 	// Just straight up build it with eopkg
 	slog.Warn("Full sandboxing is not possible with legacy format")
@@ -382,7 +383,8 @@ func (p *Package) BuildXML(notif PidNotifier, pman *EopkgManager, overlay *Overl
 
 	// Now build the package, ignore-sandbox in case someone is stupid
 	// and activates it in eopkg.conf...
-	cmd := eopkgCommand(fmt.Sprintf("eopkg build --ignore-sandbox --yes-all -O %s %s", wdir, xmlFile))
+	// NOTE: ypkg already depends on python-eopkg, so this can be changed eopkg.py3 no problem.
+	cmd := eopkgCommand(fmt.Sprintf("eopkg.py2 build --ignore-sandbox --yes-all -O %s %s", wdir, xmlFile))
 
 	slog.Info("Now starting build", "package", p.Name)
 

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -207,19 +207,19 @@ func (e *EopkgManager) Upgrade() error {
 		"sccache",
 	}
 
-	if err := ChrootExec(e.notif, e.root, eopkgCommand("eopkg upgrade -y")); err != nil {
+	if err := ChrootExec(e.notif, e.root, eopkgCommand("eopkg.bin upgrade -y")); err != nil {
 		return err
 	}
 
 	e.notif.SetActivePID(0)
-	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg install -y %s", strings.Join(newReqs, " "))))
+	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin install -y %s", strings.Join(newReqs, " "))))
 
 	return err
 }
 
 // InstallComponent will install the named component inside the chroot.
 func (e *EopkgManager) InstallComponent(comp string) error {
-	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg install -c %v -y", comp)))
+	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin install -c %v -y", comp)))
 	e.notif.SetActivePID(0)
 
 	return err
@@ -325,11 +325,11 @@ func (e *EopkgManager) GetRepos() ([]*EopkgRepo, error) {
 // AddRepo will attempt to add a repo to the filesystem.
 func (e *EopkgManager) AddRepo(id, source string) error {
 	e.notif.SetActivePID(0)
-	return ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg add-repo '%s' '%s'", id, source)))
+	return ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin add-repo '%s' '%s'", id, source)))
 }
 
 // RemoveRepo will attempt to remove a named repo from the filesystem.
 func (e *EopkgManager) RemoveRepo(id string) error {
 	e.notif.SetActivePID(0)
-	return ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg remove-repo '%s'", id)))
+	return ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin remove-repo '%s'", id)))
 }

--- a/builder/index.go
+++ b/builder/index.go
@@ -76,7 +76,7 @@ func (p *Package) Index(notif PidNotifier, dir string, overlay *Overlay) error {
 
 	slog.Debug("Now indexing")
 
-	command := fmt.Sprintf("cd %s; %s", IndexBindTarget, eopkgCommand("eopkg index --skip-signing ."))
+	command := fmt.Sprintf("cd %s; %s", IndexBindTarget, eopkgCommand("eopkg.bin index --skip-signing ."))
 	if err := ChrootExec(notif, overlay.MountPoint, command); err != nil {
 		slog.Error("Indexing failed", "dir", dir, "err", err)
 		return err

--- a/builder/repos.go
+++ b/builder/repos.go
@@ -58,7 +58,7 @@ func (p *Package) addLocalRepo(notif PidNotifier, o *Overlay, pkgManager *EopkgM
 	if repo.AutoIndex {
 		slog.Debug("Reindexing repository", "name", repo.Name)
 
-		command := fmt.Sprintf("cd %s/%s; %s", BindRepoDir, repo.Name, eopkgCommand("eopkg index --skip-signing ."))
+		command := fmt.Sprintf("cd %s/%s; %s", BindRepoDir, repo.Name, eopkgCommand("eopkg.bin index --skip-signing ."))
 		err := ChrootExec(notif, o.MountPoint, command)
 		notif.SetActivePID(0)
 


### PR DESCRIPTION
In various tests, this is showing a speedup for install operations on the order of 20-25% (very noticeable for e.g. the ISO generation scripts).

This is also part of the preparation for dropping the py2 pisi package (which owns the `eopkg` symlink at the time of this writing).

Note that this will keep using `eopkg.py2` for building old pspec.xml packages for now; switching to using the explicit version avoids solbuild having to rely on which package owns the `eopkg` symlink.

When the epoch happens and eopkg.py2 is dropped from the repo, BuildXML needs to be changed to use `eopkg.py3`.