### PR TITLE
builder: Make the eopkg binary configurable

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -327,7 +327,7 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 	buildDir := filepath.Join(BuildUserHome, "YPKG")
 
 	// Now build the package
-	cmd := fmt.Sprintf("ypkg-build -D %s -B %s %s", workDir, buildDir, ymlFile)
+	cmd := fmt.Sprintf("%s -D %s -B %s %s", ypkgBuildCommand, workDir, buildDir, ymlFile)
 	if DisableColors {
 		cmd += " -n"
 	}
@@ -385,7 +385,8 @@ func (p *Package) BuildXML(notif PidNotifier, pman *EopkgManager, overlay *Overl
 	// Now build the package, ignore-sandbox in case someone is stupid
 	// and activates it in eopkg.conf...
 	// NOTE: ypkg already depends on python-eopkg, so this can be changed eopkg.py3 no problem.
-	cmd := eopkgCommand(fmt.Sprintf("eopkg.py2 build --ignore-sandbox --yes-all -O %s %s", wdir, xmlFile))
+	cmd := eopkgCommand(fmt.Sprintf("%s build --ignore-sandbox --yes-all -O %s %s",
+		xmlBuildCommand, wdir, xmlFile))
 
 	slog.Info("Now starting build", "package", p.Name)
 

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -219,7 +219,7 @@ func (e *EopkgManager) Upgrade() error {
 
 // InstallComponent will install the named component inside the chroot.
 func (e *EopkgManager) InstallComponent(comp string) error {
-	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin install -c %v -y", comp)))
+	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin install -y -c %v", comp)))
 	e.notif.SetActivePID(0)
 
 	return err

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -28,6 +28,12 @@ import (
 	"github.com/getsolus/libosdev/disk"
 )
 
+var (
+	installCommand   = "eopkg.bin"  // Command used for installing packages
+	ypkgBuildCommand = "ypkg-build" // Command used for building package.yml recipes
+	xmlBuildCommand  = "eopkg.py2"  // Command used for building pspec.xml recipes
+)
+
 // eopkgCommand utility wraps all eopkg calls to autodisable colours
 // where appropriate, as eopkg largely ignores the console type.
 func eopkgCommand(c string) string {
@@ -207,19 +213,22 @@ func (e *EopkgManager) Upgrade() error {
 		"sccache",
 	}
 
-	if err := ChrootExec(e.notif, e.root, eopkgCommand("eopkg.bin upgrade -y")); err != nil {
+	if err := ChrootExec(e.notif, e.root, eopkgCommand(installCommand+" upgrade -y")); err != nil {
 		return err
 	}
 
 	e.notif.SetActivePID(0)
-	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin install -y %s", strings.Join(newReqs, " "))))
+	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("%s install -y %s",
+		installCommand, strings.Join(newReqs, " "))))
 
 	return err
 }
 
 // InstallComponent will install the named component inside the chroot.
 func (e *EopkgManager) InstallComponent(comp string) error {
-	err := ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin install -y -c %v", comp)))
+	err := ChrootExec(e.notif, e.root,
+		eopkgCommand(fmt.Sprintf("%s install -y -c %v", installCommand, comp)))
+
 	e.notif.SetActivePID(0)
 
 	return err
@@ -325,11 +334,13 @@ func (e *EopkgManager) GetRepos() ([]*EopkgRepo, error) {
 // AddRepo will attempt to add a repo to the filesystem.
 func (e *EopkgManager) AddRepo(id, source string) error {
 	e.notif.SetActivePID(0)
-	return ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin add-repo '%s' '%s'", id, source)))
+	return ChrootExec(e.notif, e.root,
+		eopkgCommand(fmt.Sprintf("%s add-repo '%s' '%s'", installCommand, id, source)))
 }
 
 // RemoveRepo will attempt to remove a named repo from the filesystem.
 func (e *EopkgManager) RemoveRepo(id string) error {
 	e.notif.SetActivePID(0)
-	return ChrootExec(e.notif, e.root, eopkgCommand(fmt.Sprintf("eopkg.bin remove-repo '%s'", id)))
+	return ChrootExec(e.notif, e.root,
+		eopkgCommand(fmt.Sprintf("%s remove-repo '%s'", installCommand, id)))
 }

--- a/builder/index.go
+++ b/builder/index.go
@@ -76,7 +76,7 @@ func (p *Package) Index(notif PidNotifier, dir string, overlay *Overlay) error {
 
 	slog.Debug("Now indexing")
 
-	command := fmt.Sprintf("cd %s; %s", IndexBindTarget, eopkgCommand("eopkg.bin index --skip-signing ."))
+	command := fmt.Sprintf("cd %s; %s", IndexBindTarget, eopkgCommand(installCommand+" index --skip-signing ."))
 	if err := ChrootExec(notif, overlay.MountPoint, command); err != nil {
 		slog.Error("Indexing failed", "dir", dir, "err", err)
 		return err

--- a/builder/manager.go
+++ b/builder/manager.go
@@ -129,6 +129,26 @@ func (m *Manager) SetManifestTarget(target string) {
 	m.manifestTarget = strings.TrimSpace(target)
 }
 
+// SetCommands overrides the eopkg binary used for all eopkg commands.
+func (m *Manager) SetCommands(eopkg string, ypkg string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if eopkg != "" {
+		installCommand = eopkg
+		xmlBuildCommand = eopkg
+	}
+
+	if ypkg != "" {
+		ypkgBuildCommand = ypkg
+	}
+
+	slog.Debug("Set binaries",
+		"eopkg", installCommand,
+		"eopkg_xml", xmlBuildCommand,
+		"ypkg", ypkgBuildCommand)
+}
+
 // SetProfile will attempt to initialise the manager with a given profile
 // Currently this is locked to a backing image specification, but in future
 // will be expanded to support profiles *based* on backing images.

--- a/builder/repos.go
+++ b/builder/repos.go
@@ -58,7 +58,7 @@ func (p *Package) addLocalRepo(notif PidNotifier, o *Overlay, pkgManager *EopkgM
 	if repo.AutoIndex {
 		slog.Debug("Reindexing repository", "name", repo.Name)
 
-		command := fmt.Sprintf("cd %s/%s; %s", BindRepoDir, repo.Name, eopkgCommand("eopkg.bin index --skip-signing ."))
+		command := fmt.Sprintf("cd %s/%s; %s", BindRepoDir, repo.Name, eopkgCommand(installCommand+" index --skip-signing ."))
 		err := ChrootExec(notif, o.MountPoint, command)
 		notif.SetActivePID(0)
 

--- a/builder/util.go
+++ b/builder/util.go
@@ -194,6 +194,8 @@ func SaneEnvironment(username, home string) []string {
 // ChrootExec is a simple wrapper to return a correctly set up chroot command,
 // so that we can store the PID, for long running tasks.
 func ChrootExec(notif PidNotifier, dir, command string) error {
+	slog.Debug("Executing in chroot", "dir", dir, "command", command)
+
 	args := []string{dir, "/bin/sh", "-c", command}
 	c := exec.Command("chroot", args...)
 	c.Stdout = os.Stdout

--- a/cli/build.go
+++ b/cli/build.go
@@ -101,6 +101,9 @@ func BuildRun(r *cmd.Root, s *cmd.Sub) {
 	if err != nil {
 		os.Exit(1)
 	}
+
+	manager.SetCommands(rFlags.Eopkg, rFlags.YPKG)
+
 	// Safety first...
 	if err = manager.SetProfile(rFlags.Profile); err != nil {
 		os.Exit(1)

--- a/cli/chroot.go
+++ b/cli/chroot.go
@@ -82,7 +82,10 @@ func ChrootRun(r *cmd.Root, s *cmd.Sub) {
 	if err != nil {
 		os.Exit(1)
 	}
-	// Safety first..
+
+	manager.SetCommands(rFlags.Eopkg, rFlags.YPKG)
+
+	// Safety first...
 	if err = manager.SetProfile(rFlags.Profile); err != nil {
 		os.Exit(1)
 	}

--- a/cli/index.go
+++ b/cli/index.go
@@ -74,7 +74,10 @@ func IndexRun(r *cmd.Root, s *cmd.Sub) {
 	if err != nil {
 		os.Exit(1)
 	}
-	// Safety first..
+
+	manager.SetCommands(rFlags.Eopkg, rFlags.YPKG)
+
+	// Safety first...
 	if err = manager.SetProfile(rFlags.Profile); err != nil {
 		os.Exit(1)
 	}

--- a/cli/init.go
+++ b/cli/init.go
@@ -74,6 +74,9 @@ func InitRun(r *cmd.Root, s *cmd.Sub) {
 		slog.Error(err.Error())
 		panic(err)
 	}
+
+	manager.SetCommands(rFlags.Eopkg, rFlags.YPKG)
+
 	// Safety first...
 	if err = manager.SetProfile(rFlags.Profile); err != nil {
 		slog.Error(err.Error())

--- a/cli/root.go
+++ b/cli/root.go
@@ -35,10 +35,14 @@ var Root = cmd.Root{
 }
 
 // GlobalFlags are available to all sub-commands.
+//
+//nolint:tagalign // asks for weird alignment
 type GlobalFlags struct {
-	Debug   bool   `short:"d" long:"debug"    desc:"Enable debug message"`
-	NoColor bool   `short:"n" long:"no-color" desc:"Disable color output"`
-	Profile string `short:"p" long:"profile"  desc:"Build profile to use"`
+	Debug   bool   `short:"d" long:"debug"     desc:"Enable debug message"`
+	NoColor bool   `short:"n" long:"no-color"  desc:"Disable color output"`
+	Profile string `short:"p" long:"profile"   desc:"Build profile to use"`
+	Eopkg   string `          long:"eopkg-bin" desc:"eopkg binary to use"`
+	YPKG    string `          long:"ypkg-bin"  desc:"ypkg binary to use"`
 }
 
 // FindLikelyArg will look in the current directory to see if common path names exist,

--- a/cli/update.go
+++ b/cli/update.go
@@ -59,6 +59,9 @@ func UpdateRun(r *cmd.Root, c *cmd.Sub) {
 	if err != nil {
 		log.Panic(err.Error())
 	}
+
+	manager.SetCommands(rFlags.Eopkg, rFlags.YPKG)
+
 	// Safety first...
 	if err = manager.SetProfile(rFlags.Profile); err != nil {
 		if errors.Is(err, builder.ErrProfileNotInstalled) {


### PR DESCRIPTION
This PR supersedes #105 by making the used binaries of eopkg and ypkg configurable using the `--ypkg-bin` and `--eopkg-bin` flags. This allows for comparative tests.