### PR TITLE
ci: Remove libgit2 install from workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,10 +19,6 @@ jobs:
         with:
           go-version: '1.21'
           cache: false
-      # Install libgit2-dev 1.5 for git2go
-      - run: sudo apt-get install -qqy wget
-      - run: wget http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgit2/libgit2-{1.5,dev}_1.5.1+ds-1ubuntu1_amd64.deb
-      - run: sudo apt-get install -qqy ./*.deb
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:


### PR DESCRIPTION
This is no longer needed after the switch to `go-git`.