### PR TITLE
builder: Detect which ypkg command to use

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -249,7 +249,13 @@ func (p *Package) PrepYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager,
 	wdir := p.GetWorkDirInternal()
 	ymlFile := filepath.Join(wdir, filepath.Base(p.Path))
 
-	cmd := fmt.Sprintf("ypkg-install-deps --eopkg-cmd='%s' -f %s", installCommand, ymlFile)
+	var cmd string
+	if PathExists("/usr/bin/ypkg-install-deps") {
+		cmd = fmt.Sprintf("ypkg-install-deps --eopkg-cmd='%s' -f %s", installCommand, ymlFile)
+	} else {
+		cmd = fmt.Sprintf("ypkg install-deps --eopkg-cmd '%s' -f %s", installCommand, ymlFile)
+	}
+
 	if DisableColors {
 		cmd += " -n"
 	}
@@ -327,6 +333,15 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 	buildDir := filepath.Join(BuildUserHome, "YPKG")
 
 	// Now build the package
+
+	if ypkgBuildCommand == "" {
+		if PathExists("/usr/bin/ypkg-build") {
+			ypkgBuildCommand = "ypkg-build"
+		} else {
+			ypkgBuildCommand = "ypkg build"
+		}
+	}
+
 	cmd := fmt.Sprintf("%s -D %s -B %s %s", ypkgBuildCommand, workDir, buildDir, ymlFile)
 	if DisableColors {
 		cmd += " -n"

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -29,9 +29,9 @@ import (
 )
 
 var (
-	installCommand   = "eopkg.bin"  // Command used for installing packages
-	ypkgBuildCommand = "ypkg-build" // Command used for building package.yml recipes
-	xmlBuildCommand  = "eopkg.py2"  // Command used for building pspec.xml recipes
+	installCommand   = "eopkg.bin" // Command used for installing packages
+	ypkgBuildCommand = ""          // Command used for building package.yml recipes
+	xmlBuildCommand  = "eopkg.py2" // Command used for building pspec.xml recipes
 )
 
 // eopkgCommand utility wraps all eopkg calls to autodisable colours


### PR DESCRIPTION
Once https://github.com/getsolus/ypkg/pull/114 lands, the CLI will be changed. Instead of having separate scripts that call into `ypkg2`, there will be a single entry-point with subcommands.

This commit checks for the presence of the old scripts, and uses the new command syntax if they are not available.
