### PR TITLE
golangci-lint.yml: Update to a (much) newer version of golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.61
+          version: v2.40


### PR DESCRIPTION
The CI is failing for reasons very unrelated to our code. I think the almost-a-year-old linter might have something to do with it.