### PR TITLE
Try a linter version that exists

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.40
+          version: v2.4.0


### PR DESCRIPTION
Let's see: Does the linter work better if you type *all* the characters in the version string?