### PR TITLE
Reformat .golangci.yaml to work with their new configuration format

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,35 @@
 ---
+version: "2"
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+severity:
+  default: major
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/getsolus/solbuild)
+
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
 linters:
-  enable-all: true
+  default: all
   disable:
     # Disabled to get codebase to pass the linter.
     # We can enable these one at a time.
@@ -17,99 +46,84 @@ linters:
     - noctx
     - perfsprint
     - revive
-    - stylecheck
     - wrapcheck
     # Disabled permanently
-    - exhaustruct     # structs may be uninitialized
-    - nlreturn        # covered by wsl cuddle rules
-    - paralleltest    # tests are acceptable in sequence
-    - goimports       # conflicts with GCI
     - depguard        # manage using go.mod for now
+    - exhaustruct     # structs may be uninitialized
+    - funcorder       # functions are allowed in any order
+    - nlreturn        # covered by wsl cuddle rules
+    - noinlineerr     # inline errors are allowed for readability
     - nonamedreturns  # named returns are acceptable in short functions
+    - paralleltest    # tests are acceptable in sequence
     # Deprecated
-    - execinquery
-    - exportloopref
-    - gomnd
-severity:
-  default-severity: major
+    - wsl
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - err113
+          - errcheck
+          - gochecknoglobals
+          - gosec
+          - wrapcheck
+        path: _test\.go
+      - linters: [staticcheck]
+        text: "ST1000:"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
 
-issues:
-  fast: false
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude-use-default: false
-  exclude-case-sensitive: true
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gochecknoglobals
-        - errcheck
-        - wrapcheck
-        - gosec
-        - goerr113
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
 
-linters-settings:
-  varnamelen:
-    min-name-length: 1
+    misspell:
+      ignore-rules:
+        - evolveos
 
-  exhaustive:
-    default-signifies-exhaustive: true
+    revive:
+      enable-all-rules: false
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
 
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/getsolus/solbuild)
+    staticcheck:
+      checks:
+        - all
 
-  gomnd:
-    ignored-numbers: ['2', '4', '8', '16', '32', '64', '10']
+    tagalign:
+      order:
+        - zero
+        - short
+        - long
+        - desc
 
-  gosec:
-    excludes: []
-
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment  # misalignment is accepted
-
-  misspell:
-    ignore-words:
-      - evolveos
-
-  revive:
-    enable-all-rules: false
-    rules:  # see https://github.com/mgechev/revive#recommended-configuration
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: if-return
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: unused-parameter
-      - name: unreachable-code
-      - name: redefines-builtin-id
-
-  stylecheck:
-    checks: [all]
-
-  tagalign:
-    order:
-      - zero
-      - short
-      - long
-      - desc
+    varnamelen:
+      min-name-length: 1

--- a/builder/build.go
+++ b/builder/build.go
@@ -35,7 +35,7 @@ func (p *Package) CreateDirs(o *Overlay) error {
 
 	for _, p := range dirs {
 		if err := os.MkdirAll(p, 0o0755); err != nil {
-			return fmt.Errorf("Failed to create required directory %s. Reason: %w", p, err)
+			return fmt.Errorf("failed to create required directory %s. Reason: %w", p, err)
 		}
 	}
 
@@ -47,18 +47,18 @@ func (p *Package) CreateDirs(o *Overlay) error {
 
 			// Cache directories in build root.
 			if err := os.MkdirAll(inRootCacheDir, 0o0755); err != nil {
-				return fmt.Errorf("Failed to create cache directory %s in build root, reason: %w", inRootCacheDir, err)
+				return fmt.Errorf("failed to create cache directory %s in build root, reason: %w", inRootCacheDir, err)
 			}
 
 			// Cache directory in host.
 			// Ensure we have root owned cache directories.
 			if err := os.MkdirAll(hostCacheDir, 0o0755); err != nil {
-				return fmt.Errorf("Failed to create cache directory %s for %s, reason: %w", cache.CacheDir, cache.Name, err)
+				return fmt.Errorf("failed to create cache directory %s for %s, reason: %w", cache.CacheDir, cache.Name, err)
 			}
 
 			// Ensure the build user can write to the cache directories.
 			if err := os.Chown(hostCacheDir, BuildUserID, BuildUserGID); err != nil {
-				return fmt.Errorf("Failed to chown cache directory %s in build root, reason: %w", inRootCacheDir, err)
+				return fmt.Errorf("failed to chown cache directory %s in build root, reason: %w", inRootCacheDir, err)
 			}
 		}
 	}
@@ -76,7 +76,7 @@ func (p *Package) FetchSources(o *Overlay) error {
 		}
 
 		if err := source.Fetch(); err != nil {
-			return fmt.Errorf("Failed to fetch source %s, reason: %w\n", source.GetIdentifier(), err)
+			return fmt.Errorf("failed to fetch source %s, reason: %w", source.GetIdentifier(), err)
 		}
 	}
 
@@ -95,7 +95,7 @@ func (p *Package) BindSources(o *Overlay) error {
 		// Ensure sources tree exists
 		if !PathExists(sourceDir) {
 			if err := os.MkdirAll(sourceDir, 0o0755); err != nil {
-				return fmt.Errorf("Failed to create source directory %s, reason: %w\n", sourceDir, err)
+				return fmt.Errorf("failed to create source directory %s, reason: %w", sourceDir, err)
 			}
 		}
 
@@ -118,7 +118,7 @@ func (p *Package) BindSources(o *Overlay) error {
 
 		// Bind mount local source into chroot
 		if err := mountMan.BindMount(bindConfig.BindSource, bindConfig.BindTarget, "ro"); err != nil {
-			return fmt.Errorf("Failed to bind mount source %s, reason: %w\n", bindConfig.BindTarget, err)
+			return fmt.Errorf("failed to bind mount source %s, reason: %w", bindConfig.BindTarget, err)
 		}
 
 		// Account for these to help cleanups
@@ -128,10 +128,10 @@ func (p *Package) BindSources(o *Overlay) error {
 	return nil
 }
 
-// BindCache will make all cache defined in [caches] available to the build.
+// BindCaches will make all cache defined in [caches] available to the build.
 func (p *Package) BindCaches(o *Overlay) error {
 	if p.Type == PackageTypeXML {
-		return fmt.Errorf("Failed to bind caches, reason: not YPKG build")
+		return fmt.Errorf("failed to bind caches, reason: not YPKG build")
 	}
 
 	mountMan := disk.GetMountManager()
@@ -144,7 +144,7 @@ func (p *Package) BindCaches(o *Overlay) error {
 
 		// Bind mount local ccache into chroot
 		if err := mountMan.BindMount(cacheSource, cacheDir); err != nil {
-			return fmt.Errorf("Failed to bind mount %s %s, reason: %w\n", c.Name, cacheDir, err)
+			return fmt.Errorf("failed to bind mount %s %s, reason: %w", c.Name, cacheDir, err)
 		}
 
 		o.ExtraMounts = append(o.ExtraMounts, cacheDir)
@@ -238,12 +238,12 @@ func (p *Package) PrepYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager,
 
 	if !PathExists(fpd) {
 		if err := os.MkdirAll(fpd, 0o0755); err != nil {
-			return fmt.Errorf("Failed to create packager directory %s, reason: %w\n", fpd, err)
+			return fmt.Errorf("failed to create packager directory %s, reason: %w", fpd, err)
 		}
 	}
 
 	if err := usr.WritePackager(fp); err != nil {
-		return fmt.Errorf("Failed to write packager file %s, reason: %w\n", fp, err)
+		return fmt.Errorf("failed to write packager file %s, reason: %w", fp, err)
 	}
 
 	wdir := p.GetWorkDirInternal()
@@ -258,7 +258,7 @@ func (p *Package) PrepYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager,
 	slog.Debug("Installing build dependencies", "file", ymlFile)
 
 	if err := ChrootExec(notif, overlay.MountPoint, cmd); err != nil {
-		return fmt.Errorf("Failed to install build dependencies %s, reason: %w\n", ymlFile, err)
+		return fmt.Errorf("failed to install build dependencies %s, reason: %w", ymlFile, err)
 	}
 
 	notif.SetActivePID(0)
@@ -267,13 +267,13 @@ func (p *Package) PrepYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager,
 	slog.Debug("Stopping D-BUS")
 
 	if err := pman.StopDBUS(); err != nil {
-		return fmt.Errorf("Failed to stop d-bus, reason: %w\n", err)
+		return fmt.Errorf("failed to stop d-bus, reason: %w", err)
 	}
 
 	// Chwn the directory before bringing up sources
 	cmd = fmt.Sprintf("chown -R %s:%s %s", BuildUser, BuildUser, BuildUserHome)
 	if err := ChrootExec(notif, overlay.MountPoint, cmd); err != nil {
-		return fmt.Errorf("Failed to set home directory permissions, reason: %w\n", err)
+		return fmt.Errorf("failed to set home directory permissions, reason: %w", err)
 	}
 
 	notif.SetActivePID(0)
@@ -304,7 +304,7 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 
 	// Bring up sources
 	if err := p.BindSources(overlay); err != nil {
-		return fmt.Errorf("Failed to set home directory permissions, reason: %w\n", err)
+		return fmt.Errorf("failed to set home directory permissions, reason: %w", err)
 	}
 
 	// Reaffirm the layout
@@ -344,7 +344,7 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 	slog.Info("Now starting build", "package", p.Name)
 
 	if err := ChrootExec(notif, overlay.MountPoint, cmd); err != nil {
-		return fmt.Errorf("Failed to start build of package, reason: %w\n", err)
+		return fmt.Errorf("failed to start build of package, reason: %w", err)
 	}
 
 	// Generate ABI Report
@@ -374,7 +374,7 @@ func (p *Package) BuildXML(notif PidNotifier, pman *EopkgManager, overlay *Overl
 
 	// Bring up sources
 	if err := p.BindSources(overlay); err != nil {
-		return fmt.Errorf("Cannot continue without sources.\n")
+		return fmt.Errorf("cannot continue without sources")
 	}
 
 	// Now recopy the assets prior to build
@@ -391,7 +391,7 @@ func (p *Package) BuildXML(notif PidNotifier, pman *EopkgManager, overlay *Overl
 	slog.Info("Now starting build", "package", p.Name)
 
 	if err := ChrootExec(notif, overlay.MountPoint, cmd); err != nil {
-		return fmt.Errorf("Failed to start build of package.\n")
+		return fmt.Errorf("failed to start build of package")
 	}
 
 	notif.SetActivePID(0)
@@ -400,7 +400,7 @@ func (p *Package) BuildXML(notif PidNotifier, pman *EopkgManager, overlay *Overl
 	slog.Debug("Stopping D-BUS")
 
 	if err := pman.StopDBUS(); err != nil {
-		return fmt.Errorf("Failed to stop d-bus, reason: %w\n", err)
+		return fmt.Errorf("failed to stop d-bus, reason: %w", err)
 	}
 
 	notif.SetActivePID(0)
@@ -440,7 +440,7 @@ func (p *Package) CollectAssets(overlay *Overlay, usr *UserInfo, manifestTarget 
 		tram := NewTransitManifest(manifestTarget)
 		for _, p := range collections {
 			if err := tram.AddFile(p); err != nil {
-				return fmt.Errorf("Failed to collect eopkg asset for transit manifest %s, reason: %w\n", p, err)
+				return fmt.Errorf("failed to collect eopkg asset for transit manifest %s, reason: %w", p, err)
 			}
 		}
 
@@ -472,13 +472,13 @@ func (p *Package) CollectAssets(overlay *Overlay, usr *UserInfo, manifestTarget 
 	for _, p := range collections {
 		tgt, err := filepath.Abs(filepath.Join(".", filepath.Base(p)))
 		if err != nil {
-			return fmt.Errorf("Unable to find working directory, reason: %w\n", err)
+			return fmt.Errorf("unable to find working directory, reason: %w", err)
 		}
 
 		slog.Debug("Collecting build artifact", "path", filepath.Base(p))
 
 		if err = disk.CopyFile(p, tgt); err != nil {
-			return fmt.Errorf("Unable to collect build file, reason: %w\n", err)
+			return fmt.Errorf("unable to collect build file, reason: %w", err)
 		}
 
 		slog.Debug("Setting file ownership for current user", "uid", usr.UID, "gid", usr.GID, "path", filepath.Base(p))
@@ -519,7 +519,7 @@ func (p *Package) Build(notif PidNotifier, history *PackageHistory, profile *Pro
 
 	// Ensure source assets are in place
 	if err := p.CopyAssets(history, overlay); err != nil {
-		return fmt.Errorf("Failed to copy required source assets, reason: %w\n", err)
+		return fmt.Errorf("failed to copy required source assets, reason: %w", err)
 	}
 
 	slog.Debug("Validating sources")
@@ -537,24 +537,24 @@ func (p *Package) Build(notif PidNotifier, history *PackageHistory, profile *Pro
 	slog.Debug("Starting D-BUS")
 
 	if err := pman.StartDBUS(); err != nil {
-		return fmt.Errorf("Failed to start d-bus, reason: %w\n", err)
+		return fmt.Errorf("failed to start d-bus, reason: %w", err)
 	}
 
 	// Get the repos in place before asserting anything
 	if err := p.ConfigureRepos(notif, overlay, pman, profile); err != nil {
-		return fmt.Errorf("Configuring repositories failed, reason: %w\n", err)
+		return fmt.Errorf("configuring repositories failed, reason: %w", err)
 	}
 
 	slog.Debug("Upgrading system base")
 
 	if err := pman.Upgrade(); err != nil {
-		return fmt.Errorf("Failed to upgrade rootfs, reason: %w\n", err)
+		return fmt.Errorf("failed to upgrade rootfs, reason: %w", err)
 	}
 
 	slog.Debug("Asserting system.devel component installation")
 
 	if err := pman.InstallComponent("system.devel"); err != nil {
-		return fmt.Errorf("Failed to assert system.devel, reason: %w\n", err)
+		return fmt.Errorf("failed to assert system.devel, reason: %w", err)
 	}
 
 	// Ensure all directories are in place

--- a/builder/copy.go
+++ b/builder/copy.go
@@ -59,7 +59,7 @@ func CopyAll(source, destdir string) error {
 			slog.Debug("Creating target directory", "dir", destdir)
 
 			if err = os.MkdirAll(destdir, 0o0755); err != nil {
-				return fmt.Errorf("Failed to create target directory: %s, reason: %w\n", destdir, err)
+				return fmt.Errorf("failed to create target directory: %s, reason: %w", destdir, err)
 			}
 		}
 
@@ -67,7 +67,7 @@ func CopyAll(source, destdir string) error {
 		slog.Debug("Copying source", "source", source, "target", tgt)
 
 		if err = disk.CopyFile(source, tgt); err != nil {
-			return fmt.Errorf("Failed to copy source asset to target: source='%s' target='%s', reason: %w\n", source, tgt, err)
+			return fmt.Errorf("failed to copy source asset to target: source=%q, target=%q, reason: %w", source, tgt, err)
 		}
 	}
 

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -95,14 +95,14 @@ func (e *EopkgManager) CopyAssets() error {
 			slog.Debug("Creating required directory", "path", dirName)
 
 			if err := os.MkdirAll(dirName, 0o0755); err != nil {
-				return fmt.Errorf("Failed to create required asset directory %s, reason %w\n", dirName, err)
+				return fmt.Errorf("failed to create required asset directory %s, reason %w", dirName, err)
 			}
 		}
 
 		slog.Debug("Copying host asset", "key", key)
 
 		if err := disk.CopyFile(key, value); err != nil {
-			return fmt.Errorf("Failed to copy host asset %s, reason: %w\n", key, err)
+			return fmt.Errorf("failed to copy host asset %s, reason: %w", key, err)
 		}
 	}
 
@@ -127,7 +127,7 @@ func (e *EopkgManager) Init() error {
 		slog.Debug("Creating system-wide package cache", "path", e.cacheSource)
 
 		if err := os.MkdirAll(e.cacheSource, 0o0755); err != nil {
-			return fmt.Errorf("Failed to create package cache %s, reason: %w\n", e.cacheSource, err)
+			return fmt.Errorf("failed to create package cache %s, reason: %w", e.cacheSource, err)
 		}
 	}
 
@@ -249,12 +249,12 @@ func EnsureEopkgLayout(root string) error {
 	runPath := filepath.Join(root, "run")
 	if PathExists(runPath) {
 		if err := os.RemoveAll(runPath); err != nil {
-			return fmt.Errorf("Failed to clean stale /run, reason: %w\n", err)
+			return fmt.Errorf("failed to clean stale /run, reason: %w", err)
 		}
 	}
 
 	if err := os.MkdirAll(runPath, 0o0755); err != nil {
-		return fmt.Errorf("Failed to clean stale /run, reason: %w\n", err)
+		return fmt.Errorf("failed to clean stale /run, reason: %w", err)
 	}
 
 	// Construct the required directories in the tree
@@ -334,6 +334,7 @@ func (e *EopkgManager) GetRepos() ([]*EopkgRepo, error) {
 // AddRepo will attempt to add a repo to the filesystem.
 func (e *EopkgManager) AddRepo(id, source string) error {
 	e.notif.SetActivePID(0)
+
 	return ChrootExec(e.notif, e.root,
 		eopkgCommand(fmt.Sprintf("%s add-repo '%s' '%s'", installCommand, id, source)))
 }
@@ -341,6 +342,7 @@ func (e *EopkgManager) AddRepo(id, source string) error {
 // RemoveRepo will attempt to remove a named repo from the filesystem.
 func (e *EopkgManager) RemoveRepo(id string) error {
 	e.notif.SetActivePID(0)
+
 	return ChrootExec(e.notif, e.root,
 		eopkgCommand(fmt.Sprintf("%s remove-repo '%s'", installCommand, id)))
 }

--- a/builder/lockfile.go
+++ b/builder/lockfile.go
@@ -27,11 +27,11 @@ import (
 
 var (
 	// ErrDeadLockFile is returned when an dead lockfile was encountered.
-	ErrDeadLockFile = errors.New("Dead lockfile")
+	ErrDeadLockFile = errors.New("dead lockfile")
 
 	// ErrOwnedLockFile is returned when the lockfile is already owned by
 	// another active process.
-	ErrOwnedLockFile = errors.New("File is locked")
+	ErrOwnedLockFile = errors.New("file is locked")
 )
 
 // A LockFile encapsulates locking functionality.

--- a/builder/main.go
+++ b/builder/main.go
@@ -27,7 +27,7 @@ import (
 // Spelled this way so people don't get confused :P.
 var DisableColors bool
 
-// Controls whether or not we generate an ABI report.
+// DisableABIReport controls whether or not we generate an ABI report.
 var DisableABIReport bool
 
 const (

--- a/builder/namespaces.go
+++ b/builder/namespaces.go
@@ -27,7 +27,7 @@ func ConfigureNamespace() error {
 	slog.Debug("Configuring container namespace")
 
 	if err := syscall.Unshare(syscall.CLONE_NEWNS | syscall.CLONE_NEWIPC); err != nil {
-		return fmt.Errorf("Failed to configure namespace, reason: %w\n", err)
+		return fmt.Errorf("failed to configure namespace, reason: %w", err)
 	}
 
 	return nil
@@ -38,7 +38,7 @@ func DropNetworking() error {
 	slog.Debug("Dropping container networking")
 
 	if err := syscall.Unshare(syscall.CLONE_NEWNET | syscall.CLONE_NEWUTS); err != nil {
-		return fmt.Errorf("Failed to drop networking capabilities, reason: %w\n", err)
+		return fmt.Errorf("failed to drop networking capabilities, reason: %w", err)
 	}
 
 	return nil

--- a/builder/overlay.go
+++ b/builder/overlay.go
@@ -99,7 +99,7 @@ func (o *Overlay) EnsureDirs() error {
 		slog.Debug("Creating overlay storage directory", "path", p)
 
 		if err := os.MkdirAll(p, 0o0755); err != nil {
-			return fmt.Errorf("Failed to create overlay storage directory: dir='%s', reason: %w\n", p, err)
+			return fmt.Errorf("failed to create overlay storage directory: dir=%q, reason: %w", p, err)
 		}
 	}
 
@@ -116,7 +116,7 @@ func (o *Overlay) CleanExisting() error {
 	slog.Debug("Removing stale workspace", "path", o.BaseDir)
 
 	if err := os.RemoveAll(o.BaseDir); err != nil {
-		return fmt.Errorf("Failed to remove stale workspace: dir='%s', reason: %w\n", o.BaseDir, err)
+		return fmt.Errorf("failed to remove stale workspace: dir=%q, reason: %w", o.BaseDir, err)
 	}
 
 	return nil
@@ -148,7 +148,7 @@ func (o *Overlay) Mount() error {
 			"relatime",
 		}...)
 		if err := mountMan.Mount("tmpfs-root", o.BaseDir, "tmpfs", tmpfsOptions...); err != nil {
-			return fmt.Errorf("Failed to mount root tmpfs: point='%s' size='%s', reason: %w\n", o.BaseDir, o.TmpfsSize, err)
+			return fmt.Errorf("failed to mount root tmpfs: point=%q, size=%q, reason: %w", o.BaseDir, o.TmpfsSize, err)
 		}
 	}
 
@@ -161,7 +161,7 @@ func (o *Overlay) Mount() error {
 	slog.Debug("Mounting backing image", "point", o.Back.ImagePath)
 
 	if err := mountMan.Mount(o.Back.ImagePath, o.ImgDir, "auto", "ro", "loop"); err != nil {
-		return fmt.Errorf("Failed to mount backing image: point='%s', reason: %w\n", o.Back.ImagePath, err)
+		return fmt.Errorf("failed to mount backing image: point=%q, reason: %w", o.Back.ImagePath, err)
 	}
 
 	o.mountedImg = true
@@ -258,7 +258,7 @@ func (o *Overlay) MountVFS() error {
 		slog.Debug("Creating VFS directory", "dir", p)
 
 		if err := os.MkdirAll(p, 0o0755); err != nil {
-			return fmt.Errorf("Failed to create VFS directory. dir='%s', reason: %w\n", p, err)
+			return fmt.Errorf("failed to create VFS directory. dir='%s', reason: %w", p, err)
 		}
 	}
 
@@ -266,7 +266,7 @@ func (o *Overlay) MountVFS() error {
 	slog.Debug("Mounting vfs /dev")
 
 	if err := mountMan.Mount("devtmpfs", vfsPoints[0], "devtmpfs", "nosuid", "mode=755"); err != nil {
-		return fmt.Errorf("Failed to mount /dev, reason: %w\n", err)
+		return fmt.Errorf("failed to mount /dev, reason: %w", err)
 	}
 
 	o.mountedVFS = true
@@ -275,28 +275,28 @@ func (o *Overlay) MountVFS() error {
 	slog.Debug("Mounting vfs /dev/pts")
 
 	if err := mountMan.Mount("devpts", vfsPoints[1], "devpts", "gid=5", "mode=620", "nosuid", "noexec"); err != nil {
-		return fmt.Errorf("Failed to mount /dev/pts, reason: %w\n", err)
+		return fmt.Errorf("failed to mount /dev/pts, reason: %w", err)
 	}
 
 	// Bring up proc
 	slog.Debug("Mounting vfs /proc")
 
 	if err := mountMan.Mount("proc", vfsPoints[2], "proc", "nosuid", "noexec"); err != nil {
-		return fmt.Errorf("Failed to mount /proc, reason: %w\n", err)
+		return fmt.Errorf("failed to mount /proc, reason: %w", err)
 	}
 
 	// Bring up sys
 	slog.Debug("Mounting vfs /sys")
 
 	if err := mountMan.Mount("sysfs", vfsPoints[3], "sysfs"); err != nil {
-		return fmt.Errorf("Failed to mount /sys, reason: %w\n", err)
+		return fmt.Errorf("failed to mount /sys, reason: %w", err)
 	}
 
 	// Bring up shm
 	slog.Debug("Mounting vfs /dev/shm")
 
 	if err := mountMan.Mount("tmpfs-shm", vfsPoints[4], "tmpfs"); err != nil {
-		return fmt.Errorf("Failed to mount /dev/shm, reason: %w\n", err)
+		return fmt.Errorf("failed to mount /dev/shm, reason: %w", err)
 	}
 
 	return nil
@@ -310,7 +310,7 @@ func (o *Overlay) ConfigureNetworking() error {
 	slog.Debug("Configuring container networking")
 
 	if err := commands.ChrootExec(o.MountPoint, ipCommand); err != nil {
-		return fmt.Errorf("Failed to configure networking, reason: %w\n", err)
+		return fmt.Errorf("failed to configure networking, reason: %w", err)
 	}
 
 	return nil

--- a/builder/profile.go
+++ b/builder/profile.go
@@ -87,7 +87,7 @@ func GetAllProfiles() (map[string]*Profile, error) {
 func NewProfileFromPath(path string) (*Profile, error) {
 	basename := filepath.Base(path)
 	if !strings.HasSuffix(basename, ProfileSuffix) {
-		return nil, fmt.Errorf("Not a .profile file: %v", path)
+		return nil, fmt.Errorf("not a .profile file: %s", path)
 	}
 
 	fi, err := os.Open(path)
@@ -124,7 +124,7 @@ func NewProfileFromPath(path string) (*Profile, error) {
 	// Check all repo names are valid
 	for _, r := range profile.AddRepos {
 		if _, ok := profile.Repos[r]; !ok {
-			return nil, fmt.Errorf("Cannot enable unknown repo %v", r)
+			return nil, fmt.Errorf("cannot enable unknown repo %v", r)
 		}
 	}
 

--- a/builder/repos.go
+++ b/builder/repos.go
@@ -34,7 +34,7 @@ const (
 func (p *Package) addLocalRepo(notif PidNotifier, o *Overlay, pkgManager *EopkgManager, repo *Repo) error {
 	// Ensure the source exists too. Sorta helpful like that.
 	if !PathExists(repo.URI) {
-		return fmt.Errorf("Local repo does not exist")
+		return fmt.Errorf("local repo does not exist")
 	}
 
 	mman := disk.GetMountManager()
@@ -87,7 +87,7 @@ func (p *Package) removeRepos(pkgManager *EopkgManager, repos []string) error {
 		slog.Debug("Removing repository", "repo", id)
 
 		if err := pkgManager.RemoveRepo(id); err != nil {
-			return fmt.Errorf("Failed to remove repository %s, reason: %w\n", id, err)
+			return fmt.Errorf("failed to remove repository %s, reason: %w", id, err)
 		}
 	}
 
@@ -105,7 +105,7 @@ func (p *Package) addRepos(notif PidNotifier, o *Overlay, pkgManager *EopkgManag
 			slog.Debug("Adding local repo to system", "name", repo.Name, "uri", repo.URI)
 
 			if err := p.addLocalRepo(notif, o, pkgManager, repo); err != nil {
-				return fmt.Errorf("Failed to add local repo to system %s, reason: %w\n", repo.Name, err)
+				return fmt.Errorf("failed to add local repo to system %s, reason: %w", repo.Name, err)
 			}
 
 			continue
@@ -114,7 +114,7 @@ func (p *Package) addRepos(notif PidNotifier, o *Overlay, pkgManager *EopkgManag
 		slog.Debug("Adding repo to system", "name", repo.Name, "uri", repo.URI)
 
 		if err := pkgManager.AddRepo(repo.Name, repo.URI); err != nil {
-			return fmt.Errorf("Failed to add repo to system %s, reason: %w\n", repo.Name, err)
+			return fmt.Errorf("failed to add repo to system %s, reason: %w", repo.Name, err)
 		}
 	}
 

--- a/builder/source/simple.go
+++ b/builder/source/simple.go
@@ -131,7 +131,7 @@ func (s *SimpleSource) download(destination string) error {
 	}
 
 	// Some web servers (*cough* sourceforge) have strange redirection behavior. It's possible to work around this by clearing the Referer header on every redirect
-	headHttpClient := &http.Client{
+	headHTTPClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			for k := range req.Header {
 				if strings.ToLower(k) == "referer" {
@@ -147,7 +147,7 @@ func (s *SimpleSource) download(destination string) error {
 	}
 
 	// Do a HEAD request, following all redirects until we get the final URL.
-	headResp, err := headHttpClient.Head(s.URI)
+	headResp, err := headHTTPClient.Head(s.URI)
 	if err != nil {
 		return err
 	}

--- a/builder/transit_manifest.go
+++ b/builder/transit_manifest.go
@@ -32,7 +32,7 @@ const (
 )
 
 // ErrIllegalUpload is returned when someone is a spanner and tries uploading an unsupported file.
-var ErrIllegalUpload = errors.New("The manifest file is NOT an eopkg")
+var ErrIllegalUpload = errors.New("the manifest file is NOT an eopkg")
 
 // A TransitManifestHeader is required in all .tram uploads to ensure that both
 // the sender and recipient are talking in the same fashion.

--- a/builder/update.go
+++ b/builder/update.go
@@ -29,33 +29,33 @@ func (b *BackingImage) updatePackages(_ PidNotifier, pkgManager *EopkgManager) e
 	slog.Debug("Initialising package manager")
 
 	if err := pkgManager.Init(); err != nil {
-		return fmt.Errorf("Failed to initialise package manager, reason: %w\n", err)
+		return fmt.Errorf("failed to initialise package manager, reason: %w", err)
 	}
 
 	// Bring up dbus to do Things
 	slog.Debug("Starting D-BUS")
 
 	if err := pkgManager.StartDBUS(); err != nil {
-		return fmt.Errorf("Failed to start d-bus, reason: %w\n", err)
+		return fmt.Errorf("failed to start d-bus, reason: %w", err)
 	}
 
 	slog.Debug("Upgrading builder image")
 
 	if err := pkgManager.Upgrade(); err != nil {
-		return fmt.Errorf("Failed to perform upgrade, reason: %w\n", err)
+		return fmt.Errorf("failed to perform upgrade, reason: %w", err)
 	}
 
 	slog.Debug("Asserting system.devel component")
 
 	if err := pkgManager.InstallComponent("system.devel"); err != nil {
-		return fmt.Errorf("Failed to install system.devel, reason: %w\n", err)
+		return fmt.Errorf("failed to install system.devel, reason: %w", err)
 	}
 
 	// Cleanup now
 	slog.Debug("Stopping D-BUS")
 
 	if err := pkgManager.StopDBUS(); err != nil {
-		return fmt.Errorf("Failed to stop d-bus, reason: %w\n", err)
+		return fmt.Errorf("failed to stop d-bus, reason: %w", err)
 	}
 
 	return nil
@@ -70,7 +70,7 @@ func (b *BackingImage) Update(notif PidNotifier, pkgManager *EopkgManager) error
 
 	if !PathExists(b.RootDir) {
 		if err := os.MkdirAll(b.RootDir, 0o0755); err != nil {
-			return fmt.Errorf("Failed to create required directories, reason: %w\n", err)
+			return fmt.Errorf("failed to create required directories, reason: %w", err)
 		}
 
 		slog.Debug("Created root directory", "name", b.Name)
@@ -80,11 +80,11 @@ func (b *BackingImage) Update(notif PidNotifier, pkgManager *EopkgManager) error
 
 	// Mount the rootfs
 	if err := mountMan.Mount(b.ImagePath, b.RootDir, "auto", "loop"); err != nil {
-		return fmt.Errorf("Failed to mount rootfs %s, reason: %w\n", b.ImagePath, err)
+		return fmt.Errorf("failed to mount rootfs %s, reason: %w", b.ImagePath, err)
 	}
 
 	if err := EnsureEopkgLayout(b.RootDir); err != nil {
-		return fmt.Errorf("Failed to fix filesystem layout %s, reason: %w\n", b.ImagePath, err)
+		return fmt.Errorf("failed to fix filesystem layout %s, reason: %w", b.ImagePath, err)
 	}
 
 	procPoint := filepath.Join(b.RootDir, "proc")
@@ -93,7 +93,7 @@ func (b *BackingImage) Update(notif PidNotifier, pkgManager *EopkgManager) error
 	slog.Debug("Mounting vfs /proc")
 
 	if err := mountMan.Mount("proc", procPoint, "proc", "nosuid", "noexec"); err != nil {
-		return fmt.Errorf("Failed to mount /proc, reason: %w\n", err)
+		return fmt.Errorf("failed to mount /proc, reason: %w", err)
 	}
 
 	// Hand over to package management to do the updates

--- a/builder/users.go
+++ b/builder/users.go
@@ -85,7 +85,7 @@ func ParseUsers(passwd string) (map[string]*User, error) {
 
 		splits := strings.Split(line, ":")
 		if len(splits) != 7 {
-			return nil, fmt.Errorf("Invalid number of fields in passwd file: %d", len(splits))
+			return nil, fmt.Errorf("invalid number of fields in passwd file: %d", len(splits))
 		}
 
 		user := &User{
@@ -133,7 +133,7 @@ func ParseGroups(grps string) (map[string]*Group, error) {
 
 		splits := strings.Split(line, ":")
 		if len(splits) != 4 {
-			return nil, fmt.Errorf("Invalid number of fields in group file: %d", len(splits))
+			return nil, fmt.Errorf("invalid number of fields in group file: %d", len(splits))
 		}
 
 		group := &Group{

--- a/builder/util.go
+++ b/builder/util.go
@@ -113,7 +113,7 @@ func MurderDeathKill(root string) error {
 		var pid int
 
 		if pid, err = strconv.Atoi(spid); err != nil {
-			return fmt.Errorf("POSIX Weeps - broken pid identifier %s, reason: %w\n", spid, err)
+			return fmt.Errorf("POSIX Weeps - broken pid identifier %s, reason: %w", spid, err)
 		}
 
 		slog.Debug("Killing child process in chroot", "pid", pid)
@@ -320,7 +320,7 @@ func StartSccache(dir string) {
 func AddBuildUser(rootfs string) error {
 	pwd, err := NewPasswd(filepath.Join(rootfs, "etc"))
 	if err != nil {
-		return fmt.Errorf("Unable to discover chroot users, reason: %w\n", err)
+		return fmt.Errorf("unable to discover chroot users, reason: %w", err)
 	}
 	// User already exists
 	if _, ok := pwd.Users[BuildUser]; ok {
@@ -332,11 +332,11 @@ func AddBuildUser(rootfs string) error {
 
 	// Add the build group
 	if err := commands.AddGroup(rootfs, BuildUser, BuildUserGID); err != nil {
-		return fmt.Errorf("Failed to add build group to system, reason: %w\n", err)
+		return fmt.Errorf("failed to add build group to system, reason: %w", err)
 	}
 
 	if err := commands.AddUser(rootfs, BuildUser, BuildUserGecos, BuildUserHome, BuildUserShell, BuildUserID, BuildUserGID); err != nil {
-		return fmt.Errorf("Failed to add build user to system, reason: %w\n", err)
+		return fmt.Errorf("failed to add build user to system, reason: %w", err)
 	}
 
 	return nil

--- a/cli/init.go
+++ b/cli/init.go
@@ -147,10 +147,11 @@ func downloadImage(bk *builder.BackingImage) (err error) {
 	}
 
 	defer resp.Body.Close()
+
 	bar := pb.New64(resp.ContentLength).Set(pb.Bytes, true)
 	reader := bar.NewProxyReader(resp.Body)
-	bar.Start()
 
+	bar.Start()
 	defer bar.Finish()
 
 	bytesRemaining := resp.ContentLength


### PR DESCRIPTION
Yes, it's all completely reordered in alphabetical order. The helpful migration tool did that.

Note: The check is still failing, but now it complains about actual code things rather than broken CI. So.. a step in the right direction?