### PR TITLE
Fix "you must first set a package to build it" error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.8.0
+VERSION := 1.8.1
 BINNAME := solbuild
 
 .PHONY: build

--- a/builder/manager.go
+++ b/builder/manager.go
@@ -405,14 +405,9 @@ func (m *Manager) Chroot() error {
 		return ErrInterrupted
 	}
 
-	m.lock.Lock()
-
-	if m.pkg == nil {
-		m.lock.Unlock()
-		return ErrNoPackage
+	if err := m.checkPackage(); err != nil {
+		return err
 	}
-
-	m.lock.Unlock()
 
 	// Now get on with the real work!
 	defer m.Cleanup()
@@ -512,5 +507,9 @@ func (m *Manager) checkPackage() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	return ErrNoPackage
+	if m.pkg == nil {
+		return ErrNoPackage
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fix an issue introduced in #130 where all builds fail due to the package check always reporting a failure.