### PR TITLE
Assume new YPKG CLI, fix ypkg-bin arg

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -249,12 +249,7 @@ func (p *Package) PrepYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager,
 	wdir := p.GetWorkDirInternal()
 	ymlFile := filepath.Join(wdir, filepath.Base(p.Path))
 
-	var cmd string
-	if PathExists("/usr/bin/ypkg-install-deps") {
-		cmd = fmt.Sprintf("ypkg-install-deps --eopkg-cmd='%s' -f %s", installCommand, ymlFile)
-	} else {
-		cmd = fmt.Sprintf("ypkg install-deps --eopkg-cmd '%s' -f %s", installCommand, ymlFile)
-	}
+	cmd := fmt.Sprintf("%s install-deps --eopkg-cmd '%s' -f %s", ypkgBin, installCommand, ymlFile)
 
 	if DisableColors {
 		cmd += " -n"
@@ -333,16 +328,7 @@ func (p *Package) BuildYpkg(notif PidNotifier, usr *UserInfo, pman *EopkgManager
 	buildDir := filepath.Join(BuildUserHome, "YPKG")
 
 	// Now build the package
-
-	if ypkgBuildCommand == "" {
-		if PathExists("/usr/bin/ypkg-build") {
-			ypkgBuildCommand = "ypkg-build"
-		} else {
-			ypkgBuildCommand = "ypkg build"
-		}
-	}
-
-	cmd := fmt.Sprintf("%s -D %s -B %s %s", ypkgBuildCommand, workDir, buildDir, ymlFile)
+	cmd := fmt.Sprintf("%s build -D %s -B %s %s", ypkgBin, workDir, buildDir, ymlFile)
 	if DisableColors {
 		cmd += " -n"
 	}

--- a/builder/eopkg.go
+++ b/builder/eopkg.go
@@ -29,9 +29,9 @@ import (
 )
 
 var (
-	installCommand   = "eopkg.bin" // Command used for installing packages
-	ypkgBuildCommand = ""          // Command used for building package.yml recipes
-	xmlBuildCommand  = "eopkg.py2" // Command used for building pspec.xml recipes
+	installCommand  = "eopkg.bin" // Command used for installing packages
+	ypkgBin         = "ypkg"      // Binary used for ypkg recipes
+	xmlBuildCommand = "eopkg.py2" // Command used for building pspec.xml recipes
 )
 
 // eopkgCommand utility wraps all eopkg calls to autodisable colours

--- a/builder/manager.go
+++ b/builder/manager.go
@@ -142,13 +142,13 @@ func (m *Manager) SetCommands(eopkg string, ypkg string) {
 	}
 
 	if ypkg != "" {
-		ypkgBuildCommand = ypkg
+		ypkgBin = ypkg
 	}
 
 	slog.Debug("Set binaries",
 		"eopkg", installCommand,
 		"eopkg_xml", xmlBuildCommand,
-		"ypkg", ypkgBuildCommand)
+		"ypkg", ypkgBin)
 }
 
 // SetProfile will attempt to initialise the manager with a given profile


### PR DESCRIPTION
Consolidate seperate ypkg build/install vars into one

ypkg-bin arg regressed since d4d65f426706f26dad2de9241da4187e0dcc288b when a new ypkg was used.